### PR TITLE
NO-ISSUE Fix user displaying short message

### DIFF
--- a/connect_test.go
+++ b/connect_test.go
@@ -10,7 +10,7 @@ import (
 var currentAuth int32
 
 var auths = [][2]string{
-	{"561913", "ff65dc"},
+	{"415847", "ea445b"},
 }
 
 const (

--- a/pdu/ShortMessage.go
+++ b/pdu/ShortMessage.go
@@ -56,7 +56,7 @@ func NewLongMessageWithEncoding(message string, enc data.Encoding) (s []*ShortMe
 		message: message,
 		enc:     enc,
 	}
-	return sm.Split()
+	return sm.split()
 }
 
 // SetMessageWithEncoding sets message with encoding.
@@ -125,11 +125,12 @@ func (c *ShortMessage) GetMessageWithEncoding(enc data.Encoding) (st string, err
 	return
 }
 
-// Split one short message and split into multiple short message, with UDH
+// split one short message and split into multiple short message, with UDH
 // according to 33GP TS 23.040 section 9.2.3.24.1
-// NOTE: Split() will return array of length 1 if data length is still within the limit
+//
+// NOTE: split() will return array of length 1 if data length is still within the limit
 // The encoding interface can implement the data.Splitter interface for ad-hoc splitting rule
-func (c *ShortMessage) Split() (multiSM []*ShortMessage, err error) {
+func (c *ShortMessage) split() (multiSM []*ShortMessage, err error) {
 	var encoding data.Encoding
 	if c.enc == nil {
 		encoding = data.GSM7BIT

--- a/pdu/SubmitSM.go
+++ b/pdu/SubmitSM.go
@@ -66,7 +66,7 @@ func (c *SubmitSM) GetResponse() PDU {
 func (c *SubmitSM) Split() (multiSubSM []*SubmitSM, err error) {
 	multiSubSM = []*SubmitSM{}
 
-	multiMsg, err := c.Message.Split()
+	multiMsg, err := c.Message.split()
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Fix: https://github.com/linxGnu/gosmpp/issues/50#issuecomment-818729072

Story:
- GetMessage() works well for SM data which contains UDH and comes from SMSC
   - While `Unmarshal`, ShortMessage contains 2 parts: `udh` and raw `messageData`
   - While displaying, it's fine because we skip `udh` prefix from `messageData` and return
   - In short: `messageData` in this case **contains udh**
- However, if ShortMessage comes from user test, it won't
   -  `messageData` in this case **not contains udh**
   - Thus, messageData is truncated while displaying:
  
```go
// skip if UDHL is present
f := c.udHeader.UDHL()
```

Did this bug causes bad effect on prod?
- The answer is no:
   - ShortMessage marshaling for SubmitSM is fine, since we marshal `udh` separately from `messageData`
   - ShortMessage comes from SMSC is ok. `GetMessage` returns correct payload.

How to fix this:
- Always consider `messageData` **does not contains** `udh`
- In this way, we fix `Unmarshal` func to skip udh prefix