### PR TITLE
Refactor transmittable

### DIFF
--- a/receivable.go
+++ b/receivable.go
@@ -10,12 +10,12 @@ import (
 )
 
 type receivable struct {
-	ctx         context.Context
-	cancel      context.CancelFunc
-	wg          sync.WaitGroup
-	settings    Settings
-	conn        *Connection
-	closedState int32 // 0: not closed, 1: closed
+	ctx        context.Context
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup
+	settings   Settings
+	conn       *Connection
+	aliveState int32
 }
 
 func newReceivable(conn *Connection, settings Settings) *receivable {
@@ -29,7 +29,7 @@ func newReceivable(conn *Connection, settings Settings) *receivable {
 }
 
 func (t *receivable) close(state State) (err error) {
-	if atomic.CompareAndSwapInt32(&t.closedState, 0, 1) {
+	if atomic.CompareAndSwapInt32(&t.aliveState, Alive, Closed) {
 		// cancel to notify stop
 		t.cancel()
 

--- a/session.go
+++ b/session.go
@@ -89,7 +89,7 @@ func (s *Session) Transceiver() Transceiver {
 
 // Close session.
 func (s *Session) Close() (err error) {
-	if atomic.CompareAndSwapInt32(&s.state, 0, 1) {
+	if atomic.CompareAndSwapInt32(&s.state, Alive, Closed) {
 		err = s.close()
 	}
 	return
@@ -106,7 +106,7 @@ func (s *Session) rebind() {
 	if atomic.CompareAndSwapInt32(&s.rebinding, 0, 1) {
 		_ = s.close()
 
-		for atomic.LoadInt32(&s.state) == 0 {
+		for atomic.LoadInt32(&s.state) == Alive {
 			conn, err := s.c.Connect()
 			if err != nil {
 				if s.settings.OnRebindingError != nil {

--- a/state.go
+++ b/state.go
@@ -1,5 +1,10 @@
 package gosmpp
 
+const (
+	Alive int32 = iota
+	Closed
+)
+
 // State represents Transmitter/Receiver/Transceiver state.
 type State byte
 

--- a/transceivable.go
+++ b/transceivable.go
@@ -13,7 +13,7 @@ type transceivable struct {
 	in   *receivable
 	out  *transmittable
 
-	closedState int32 // 0: not closed, 1: closed
+	aliveState int32
 }
 
 func newTransceivable(conn *Connection, settings Settings) *transceivable {
@@ -87,7 +87,7 @@ func (t *transceivable) SystemID() string {
 
 // Close transceiver and stop underlying daemons.
 func (t *transceivable) Close() (err error) {
-	if atomic.CompareAndSwapInt32(&t.closedState, 0, 1) {
+	if atomic.CompareAndSwapInt32(&t.aliveState, Alive, Closed) {
 		// closing input and output
 		_ = t.out.close(StoppingProcessOnly)
 		_ = t.in.close(StoppingProcessOnly)

--- a/transmittable.go
+++ b/transmittable.go
@@ -3,6 +3,7 @@ package gosmpp
 import (
 	"fmt"
 	"net"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -23,14 +24,17 @@ type transmittable struct {
 
 	conn *Connection
 
-	aliveState int32
+	aliveState   int32
+	pendingWrite int32
 }
 
 func newTransmittable(conn *Connection, settings Settings) *transmittable {
 	t := &transmittable{
-		settings: settings,
-		conn:     conn,
-		input:    make(chan pdu.PDU, 1),
+		settings:     settings,
+		conn:         conn,
+		input:        make(chan pdu.PDU, 1),
+		aliveState:   Alive,
+		pendingWrite: 0,
 	}
 
 	return t
@@ -38,6 +42,10 @@ func newTransmittable(conn *Connection, settings Settings) *transmittable {
 
 func (t *transmittable) close(state State) (err error) {
 	if atomic.CompareAndSwapInt32(&t.aliveState, Alive, Closed) {
+		for atomic.LoadInt32(&t.pendingWrite) != 0 {
+			runtime.Gosched()
+		}
+
 		// notify daemon
 		close(t.input)
 
@@ -69,12 +77,15 @@ func (t *transmittable) closing(state State) {
 
 // Submit a PDU.
 func (t *transmittable) Submit(p pdu.PDU) (err error) {
+	atomic.AddInt32(&t.pendingWrite, 1)
+
 	if atomic.LoadInt32(&t.aliveState) == Alive {
 		t.input <- p
 	} else {
 		err = ErrConnectionClosing
 	}
 
+	atomic.AddInt32(&t.pendingWrite, -1)
 	return
 }
 
@@ -93,7 +104,14 @@ func (t *transmittable) start() {
 	}
 }
 
+func (t *transmittable) drain() {
+	for range t.input {
+	}
+}
+
 func (t *transmittable) loop() {
+	defer t.drain()
+
 	for p := range t.input {
 		if p != nil {
 			n, err := t.write(p)
@@ -106,7 +124,10 @@ func (t *transmittable) loop() {
 
 func (t *transmittable) loopWithEnquireLink() {
 	ticker := time.NewTicker(t.settings.EnquireLink)
-	defer ticker.Stop()
+	defer func() {
+		ticker.Stop()
+		t.drain()
+	}()
 
 	for {
 		select {

--- a/transmittable_test.go
+++ b/transmittable_test.go
@@ -113,11 +113,11 @@ func TestTransmit(t *testing.T) {
 		var tr transmittable
 		tr.input = make(chan pdu.PDU, 1)
 
-		tr.closed = true
+		tr.aliveState = 1
 		err := tr.Submit(nil)
 		require.Error(t, err)
 
-		tr.closed = false
+		tr.aliveState = 0
 		err = tr.Submit(nil)
 		require.NoError(t, err)
 	})

--- a/transmittable_test.go
+++ b/transmittable_test.go
@@ -3,6 +3,7 @@ package gosmpp
 import (
 	"fmt"
 	"net"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -121,4 +122,65 @@ func TestTransmit(t *testing.T) {
 		err = tr.Submit(nil)
 		require.NoError(t, err)
 	})
+}
+
+func TestConcurrentSubmitClose(t *testing.T) {
+	auth := nextAuth()
+	transmitter, err := NewSession(
+		TXConnector(NonTLSDialer, auth),
+		Settings{
+			ReadTimeout: 2 * time.Second,
+
+			OnPDU: func(p pdu.PDU, _ bool) {
+				t.Logf("%+v\n", p)
+			},
+
+			OnSubmitError: func(_ pdu.PDU, err error) {
+				t.Fatal(err)
+			},
+
+			OnRebindingError: func(err error) {
+				t.Fatal(err)
+			},
+
+			OnClosed: func(state State) {
+				t.Log(state)
+			},
+		}, -1)
+	require.Nil(t, err)
+	require.NotNil(t, transmitter)
+	defer func() {
+		_ = transmitter.Close()
+	}()
+
+	require.Equal(t, "MelroseLabsSMSC", transmitter.Transmitter().SystemID())
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	toStart := make(chan struct{}, 1)
+	go func() {
+		defer wg.Done()
+
+		time.Sleep(time.Millisecond)
+		for i := 0; i < 100; i++ {
+			err := transmitter.Transmitter().Submit(newSubmitSM(auth.SystemID))
+			require.True(t, err == nil || err == ErrConnectionClosing)
+
+			if i == 10 {
+				toStart <- struct{}{}
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		<-toStart
+		_ = transmitter.close()
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
This PR cleanup transmittable code with following changes:
- No need rwmutex locking
- Cleaner, simpler while handle closing state