### PR TITLE
Fix processing non-zero status from submit_sm_resp

### DIFF
--- a/pdu/PDU.go
+++ b/pdu/PDU.go
@@ -86,7 +86,10 @@ func (c *base) unmarshal(b *ByteBuffer, bodyReader func(*ByteBuffer) error) (err
 
 			skipOptionalBody := c.CommandID == data.SUBMIT_SM_RESP && c.CommandStatus != data.ESME_ROK
 			if skipOptionalBody {
-				io.Copy(ioutil.Discard, b)
+				_, err = io.Copy(ioutil.Discard, b)
+				if err != nil {
+					return
+				}
 			} else {
 				// have optional body?
 				if got < cmdLength {


### PR DESCRIPTION
According to SMPP version 3.4 specification, the submit_sm_resp body is
not returned if the command status field contains a non-zero value