### PR TITLE
feat: add descriptions to command status

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -27,6 +27,14 @@ type Auth struct {
 	SystemType string
 }
 
+type BindError struct {
+	CommandStatus data.CommandStatusType
+}
+
+func (err BindError) Error() string {
+	return fmt.Sprintf("binding error (%s): %s", err.CommandStatus, err.CommandStatus.Desc())
+}
+
 func newBindRequest(s Auth, bindingType pdu.BindingType) (bindReq *pdu.BindRequest) {
 	bindReq = pdu.NewBindRequest(bindingType)
 	bindReq.SystemID = s.SystemID
@@ -86,7 +94,7 @@ func connect(dialer Dialer, addr string, bindReq *pdu.BindRequest) (c *Connectio
 	}
 
 	if resp.CommandStatus != data.ESME_ROK {
-		err = fmt.Errorf("binding error. Command status: [%d]. Please refer to: https://github.com/linxGnu/gosmpp/blob/master/data/pkg.go for more detail about this status code", resp.CommandStatus)
+		err = BindError{CommandStatus: resp.CommandStatus}
 		_ = conn.Close()
 	} else {
 		c.systemID = resp.SystemID

--- a/connect_test.go
+++ b/connect_test.go
@@ -48,3 +48,24 @@ func TestBindingSMSC(t *testing.T) {
 		checker(t, TRXConnector(NonTLSDialer, nextAuth()))
 	})
 }
+
+func TestBindingSMSC_Error(t *testing.T) {
+	auth := Auth{SMSC: smscAddr, SystemID: "invalid"}
+	checker := func(t *testing.T, c Connector) {
+		conn, err := c.Connect()
+		require.ErrorContains(t, err, "Invalid System ID")
+		_ = conn.Close()
+	}
+
+	t.Run("TX", func(t *testing.T) {
+		checker(t, TXConnector(NonTLSDialer, auth))
+	})
+
+	t.Run("RX", func(t *testing.T) {
+		checker(t, RXConnector(NonTLSDialer, auth))
+	})
+
+	t.Run("TRX", func(t *testing.T) {
+		checker(t, TRXConnector(NonTLSDialer, auth))
+	})
+}

--- a/data/header_data.go
+++ b/data/header_data.go
@@ -8,7 +8,7 @@ type CommandStatusType int32
 // CommandIDType is type of command id.
 type CommandIDType int32
 
-//nolint
+// nolint
 const (
 	// SMPP Command ID Set
 	GENERIC_NACK          = CommandIDType(-2147483648)
@@ -40,28 +40,28 @@ const (
 	DATA_SM_RESP          = CommandIDType(-2147483389)
 )
 
-//nolint
+// nolint
 const (
 	// Command_Status Error Codes
-	ESME_ROK           = CommandStatusType(0x00000000)
-	ESME_RINVMSGLEN    = CommandStatusType(0x00000001)
-	ESME_RINVCMDLEN    = CommandStatusType(0x00000002)
-	ESME_RINVCMDID     = CommandStatusType(0x00000003)
-	ESME_RINVBNDSTS    = CommandStatusType(0x00000004)
-	ESME_RALYBND       = CommandStatusType(0x00000005)
-	ESME_RINVPRTFLG    = CommandStatusType(0x00000006)
-	ESME_RINVREGDLVFLG = CommandStatusType(0x00000007)
-	ESME_RSYSERR       = CommandStatusType(0x00000008)
-	ESME_RINVSRCADR    = CommandStatusType(0x0000000A)
-	ESME_RINVDSTADR    = CommandStatusType(0x0000000B)
-	ESME_RINVMSGID     = CommandStatusType(0x0000000C)
-	ESME_RBINDFAIL     = CommandStatusType(0x0000000D)
-	ESME_RINVPASWD     = CommandStatusType(0x0000000E)
-	ESME_RINVSYSID     = CommandStatusType(0x0000000F)
-	ESME_RCANCELFAIL   = CommandStatusType(0x00000011)
-	ESME_RREPLACEFAIL  = CommandStatusType(0x00000013)
-	ESME_RMSGQFUL      = CommandStatusType(0x00000014)
-	ESME_RINVSERTYP    = CommandStatusType(0x00000015)
+	ESME_ROK           = CommandStatusType(0x00000000) // No Error
+	ESME_RINVMSGLEN    = CommandStatusType(0x00000001) // Message Length is invalid
+	ESME_RINVCMDLEN    = CommandStatusType(0x00000002) // Command Length is invalid
+	ESME_RINVCMDID     = CommandStatusType(0x00000003) // Invalid Command ID
+	ESME_RINVBNDSTS    = CommandStatusType(0x00000004) // Incorrect BIND Status for given command
+	ESME_RALYBND       = CommandStatusType(0x00000005) // ESME Already in Bound State
+	ESME_RINVPRTFLG    = CommandStatusType(0x00000006) // Invalid Priority Flag
+	ESME_RINVREGDLVFLG = CommandStatusType(0x00000007) // Invalid Registered Delivery Flag
+	ESME_RSYSERR       = CommandStatusType(0x00000008) // System Error
+	ESME_RINVSRCADR    = CommandStatusType(0x0000000A) // Invalid Source Address
+	ESME_RINVDSTADR    = CommandStatusType(0x0000000B) // Invalid Dest Addr
+	ESME_RINVMSGID     = CommandStatusType(0x0000000C) // Message ID is invalid
+	ESME_RBINDFAIL     = CommandStatusType(0x0000000D) // Bind Failed
+	ESME_RINVPASWD     = CommandStatusType(0x0000000E) // Invalid Password
+	ESME_RINVSYSID     = CommandStatusType(0x0000000F) // Invalid System ID
+	ESME_RCANCELFAIL   = CommandStatusType(0x00000011) // Cancel SM Failed
+	ESME_RREPLACEFAIL  = CommandStatusType(0x00000013) // Replace SM Failed
+	ESME_RMSGQFUL      = CommandStatusType(0x00000014) // Message Queue Full
+	ESME_RINVSERTYP    = CommandStatusType(0x00000015) // Invalid Service Type
 
 	ESME_RADDCUSTFAIL  = CommandStatusType(0x00000019) // Failed to Add Customer
 	ESME_RDELCUSTFAIL  = CommandStatusType(0x0000001A) // Failed to delete Customer
@@ -81,36 +81,36 @@ const (
 	ESME_RPARAMRETFAIL = CommandStatusType(0x00000031) // Param Retrieve Failed
 	ESME_RINVPARAM     = CommandStatusType(0x00000032) // Invalid Param
 
-	ESME_RINVNUMDESTS = CommandStatusType(0x00000033)
-	ESME_RINVDLNAME   = CommandStatusType(0x00000034)
+	ESME_RINVNUMDESTS = CommandStatusType(0x00000033) // Invalid number of destinations
+	ESME_RINVDLNAME   = CommandStatusType(0x00000034) // Invalid Distribution List name
 
 	ESME_RINVDLMEMBDESC = CommandStatusType(0x00000035) // Invalid DL Member Description
 	ESME_RINVDLMEMBTYP  = CommandStatusType(0x00000038) // Invalid DL Member Type
 	ESME_RINVDLMODOPT   = CommandStatusType(0x00000039) // Invalid DL Modify Option
 
-	ESME_RINVDESTFLAG = CommandStatusType(0x00000040)
-	ESME_RINVSUBREP   = CommandStatusType(0x00000042)
-	ESME_RINVESMCLASS = CommandStatusType(0x00000043)
-	ESME_RCNTSUBDL    = CommandStatusType(0x00000044)
-	ESME_RSUBMITFAIL  = CommandStatusType(0x00000045)
-	ESME_RINVSRCTON   = CommandStatusType(0x00000048)
-	ESME_RINVSRCNPI   = CommandStatusType(0x00000049)
-	ESME_RINVDSTTON   = CommandStatusType(0x00000050)
-	ESME_RINVDSTNPI   = CommandStatusType(0x00000051)
-	ESME_RINVSYSTYP   = CommandStatusType(0x00000053)
-	ESME_RINVREPFLAG  = CommandStatusType(0x00000054)
-	ESME_RINVNUMMSGS  = CommandStatusType(0x00000055)
-	ESME_RTHROTTLED   = CommandStatusType(0x00000058)
+	ESME_RINVDESTFLAG = CommandStatusType(0x00000040) // Destination flag is invalid (submit_multi)
+	ESME_RINVSUBREP   = CommandStatusType(0x00000042) // Invalid ‘submit with replace’ request (i.e. submit_sm with replace_if_present_flag set)
+	ESME_RINVESMCLASS = CommandStatusType(0x00000043) // Invalid esm_class field data
+	ESME_RCNTSUBDL    = CommandStatusType(0x00000044) // Cannot Submit to Distribution List
+	ESME_RSUBMITFAIL  = CommandStatusType(0x00000045) // submit_sm or submit_multi failed
+	ESME_RINVSRCTON   = CommandStatusType(0x00000048) // Invalid Source address TON
+	ESME_RINVSRCNPI   = CommandStatusType(0x00000049) // Invalid Source address NPI
+	ESME_RINVDSTTON   = CommandStatusType(0x00000050) // Invalid Destination address TON
+	ESME_RINVDSTNPI   = CommandStatusType(0x00000051) // Invalid Destination address NPI
+	ESME_RINVSYSTYP   = CommandStatusType(0x00000053) // Invalid system_type field
+	ESME_RINVREPFLAG  = CommandStatusType(0x00000054) // Invalid replace_if_present flag
+	ESME_RINVNUMMSGS  = CommandStatusType(0x00000055) // Invalid number of messages
+	ESME_RTHROTTLED   = CommandStatusType(0x00000058) // Throttling error (ESME has exceeded allowed message limits)
 
 	ESME_RPROVNOTALLWD = CommandStatusType(0x00000059) // Provisioning Not Allowed
 
-	ESME_RINVSCHED    = CommandStatusType(0x00000061)
-	ESME_RINVEXPIRY   = CommandStatusType(0x00000062)
-	ESME_RINVDFTMSGID = CommandStatusType(0x00000063)
-	ESME_RX_T_APPN    = CommandStatusType(0x00000064)
-	ESME_RX_P_APPN    = CommandStatusType(0x00000065)
-	ESME_RX_R_APPN    = CommandStatusType(0x00000066)
-	ESME_RQUERYFAIL   = CommandStatusType(0x00000067)
+	ESME_RINVSCHED    = CommandStatusType(0x00000061) // Invalid Scheduled Delivery Time
+	ESME_RINVEXPIRY   = CommandStatusType(0x00000062) // Invalid message validity period (Expiry time)
+	ESME_RINVDFTMSGID = CommandStatusType(0x00000063) // Predefined Message Invalid or Not Found
+	ESME_RX_T_APPN    = CommandStatusType(0x00000064) // ESME Receiver Temporary App Error Code
+	ESME_RX_P_APPN    = CommandStatusType(0x00000065) // ESME Receiver Permanent App Error Code
+	ESME_RX_R_APPN    = CommandStatusType(0x00000066) // ESME Receiver Reject Message Error Code
+	ESME_RQUERYFAIL   = CommandStatusType(0x00000067) // query_sm request failed
 
 	ESME_RINVPGCUSTID      = CommandStatusType(0x00000080) // Paging Customer ID Invalid No such subscriber
 	ESME_RINVPGCUSTIDLEN   = CommandStatusType(0x00000081) // Paging Customer ID length Invalid
@@ -141,17 +141,14 @@ const (
 	ESME_RINVSMUSER        = CommandStatusType(0x0000009A) // int16 Message User Group Invalid
 	ESME_RINVRTDB          = CommandStatusType(0x0000009B) // Real Time Data broadcasts Invalid
 	ESME_RINVREGDEL        = CommandStatusType(0x0000009C) // Registered Delivery Invalid
-	// public static final  ESME_RINVOPTPARSTREAM = CommandStatusType(0x0000009D)   // KIF IW Field out of data
-	// public static final  ESME_ROPTPARNOTALLWD = CommandStatusType(0x0000009E)   // Optional Parameter not allowed
-	ESME_RINVOPTPARLEN = CommandStatusType(0x0000009F) // Invalid Optional Parameter Length
-
-	ESME_RINVOPTPARSTREAM = CommandStatusType(0x000000C0)
-	ESME_ROPTPARNOTALLWD  = CommandStatusType(0x000000C1)
-	ESME_RINVPARLEN       = CommandStatusType(0x000000C2)
-	ESME_RMISSINGOPTPARAM = CommandStatusType(0x000000C3)
-	ESME_RINVOPTPARAMVAL  = CommandStatusType(0x000000C4)
-	ESME_RDELIVERYFAILURE = CommandStatusType(0x000000FE)
-	ESME_RUNKNOWNERR      = CommandStatusType(0x000000FF)
+	ESME_RINVOPTPARLEN     = CommandStatusType(0x0000009F) // Invalid Optional Parameter Length
+	ESME_RINVOPTPARSTREAM  = CommandStatusType(0x000000C0) // KIF IW Field out of data
+	ESME_ROPTPARNOTALLWD   = CommandStatusType(0x000000C1) // Optional Parameter not allowed
+	ESME_RINVPARLEN        = CommandStatusType(0x000000C2) // Invalid Parameter Length.
+	ESME_RMISSINGOPTPARAM  = CommandStatusType(0x000000C3) // Expected Optional Parameter missing
+	ESME_RINVOPTPARAMVAL   = CommandStatusType(0x000000C4) // Invalid Optional Parameter Value
+	ESME_RDELIVERYFAILURE  = CommandStatusType(0x000000FE) // Delivery Failure (used for data_sm_resp)
+	ESME_RUNKNOWNERR       = CommandStatusType(0x000000FF) // Unknown Error
 
 	ESME_LAST_ERROR = CommandStatusType(0x0000012C) // THE VALUE OF THE LAST ERROR CODE
 )

--- a/data/header_data_string.go
+++ b/data/header_data_string.go
@@ -221,6 +221,213 @@ func (i CommandStatusType) String() string {
 	}
 	return "CommandStatusType(" + strconv.FormatInt(int64(i), 10) + ")"
 }
+
+func (i CommandStatusType) Desc() string {
+	switch i {
+	case ESME_ROK:
+		return "No Error"
+	case ESME_RINVMSGLEN:
+		return "Message Length is invalid"
+	case ESME_RINVCMDLEN:
+		return "Command Length is invalid"
+	case ESME_RINVCMDID:
+		return "Invalid Command ID"
+	case ESME_RINVBNDSTS:
+		return "Incorrect BIND Status for given command"
+	case ESME_RALYBND:
+		return "ESME Already in Bound State"
+	case ESME_RINVPRTFLG:
+		return "Invalid Priority Flag"
+	case ESME_RINVREGDLVFLG:
+		return "Invalid Registered Delivery Flag"
+	case ESME_RSYSERR:
+		return "System Error"
+	case ESME_RINVSRCADR:
+		return "Invalid Source Address"
+	case ESME_RINVDSTADR:
+		return "Invalid Dest Addr"
+	case ESME_RINVMSGID:
+		return "Message ID is invalid"
+	case ESME_RBINDFAIL:
+		return "Bind Failed"
+	case ESME_RINVPASWD:
+		return "Invalid Password"
+	case ESME_RINVSYSID:
+		return "Invalid System ID"
+	case ESME_RCANCELFAIL:
+		return "Cancel SM Failed"
+	case ESME_RREPLACEFAIL:
+		return "Replace SM Failed"
+	case ESME_RMSGQFUL:
+		return "Message Queue Full"
+	case ESME_RINVSERTYP:
+		return "Invalid Service Type"
+	case ESME_RADDCUSTFAIL:
+		return "Failed to Add Customer"
+	case ESME_RDELCUSTFAIL:
+		return "Failed to delete Customer"
+	case ESME_RMODCUSTFAIL:
+		return "Failed to modify customer"
+	case ESME_RENQCUSTFAIL:
+		return "Failed to Enquire Customer"
+	case ESME_RINVCUSTID:
+		return "Invalid Customer ID"
+	case ESME_RINVCUSTNAME:
+		return "Invalid Customer Name"
+	case ESME_RINVCUSTADR:
+		return "Invalid Customer Address"
+	case ESME_RINVADR:
+		return "Invalid Address"
+	case ESME_RCUSTEXIST:
+		return "Customer Exists"
+	case ESME_RCUSTNOTEXIST:
+		return "Customer does not exist"
+	case ESME_RADDDLFAIL:
+		return "Failed to Add DL"
+	case ESME_RMODDLFAIL:
+		return "Failed to modify DL"
+	case ESME_RDELDLFAIL:
+		return "Failed to Delete DL"
+	case ESME_RVIEWDLFAIL:
+		return "Failed to View DL"
+	case ESME_RLISTDLSFAIL:
+		return "Failed to list DLs"
+	case ESME_RPARAMRETFAIL:
+		return "Param Retrieve Failed"
+	case ESME_RINVPARAM:
+		return "Invalid Param"
+	case ESME_RINVNUMDESTS:
+		return "Invalid number of destinations"
+	case ESME_RINVDLNAME:
+		return "Invalid Distribution List name"
+	case ESME_RINVDLMEMBDESC:
+		return "Invalid DL Member Description"
+	case ESME_RINVDLMEMBTYP:
+		return "Invalid DL Member Type"
+	case ESME_RINVDLMODOPT:
+		return "Invalid DL Modify Option"
+	case ESME_RINVDESTFLAG:
+		return "Destination flag is invalid (submit_multi)"
+	case ESME_RINVSUBREP:
+		return "Invalid ‘submit with replace’ request (i.e. submit_sm with replace_if_present_flag set)"
+	case ESME_RINVESMCLASS:
+		return "Invalid esm_class field data"
+	case ESME_RCNTSUBDL:
+		return "Cannot Submit to Distribution List"
+	case ESME_RSUBMITFAIL:
+		return "submit_sm or submit_multi failed"
+	case ESME_RINVSRCTON:
+		return "Invalid Source address TON"
+	case ESME_RINVSRCNPI:
+		return "Invalid Source address NPI"
+	case ESME_RINVDSTTON:
+		return "Invalid Destination address TON"
+	case ESME_RINVDSTNPI:
+		return "Invalid Destination address NPI"
+	case ESME_RINVSYSTYP:
+		return "Invalid system_type field"
+	case ESME_RINVREPFLAG:
+		return "Invalid replace_if_present flag"
+	case ESME_RINVNUMMSGS:
+		return "Invalid number of messages"
+	case ESME_RTHROTTLED:
+		return "Throttling error (ESME has exceeded allowed message limits)"
+	case ESME_RPROVNOTALLWD:
+		return "Provisioning Not Allowed"
+	case ESME_RINVSCHED:
+		return "Invalid Scheduled Delivery Time"
+	case ESME_RINVEXPIRY:
+		return "Invalid message validity period (Expiry time)"
+	case ESME_RINVDFTMSGID:
+		return "Predefined Message Invalid or Not Found"
+	case ESME_RX_T_APPN:
+		return "ESME Receiver Temporary App Error Code"
+	case ESME_RX_P_APPN:
+		return "ESME Receiver Permanent App Error Code"
+	case ESME_RX_R_APPN:
+		return "ESME Receiver Reject Message Error Code"
+	case ESME_RQUERYFAIL:
+		return "query_sm request failed"
+	case ESME_RINVPGCUSTID:
+		return "Paging Customer ID Invalid No such subscriber"
+	case ESME_RINVPGCUSTIDLEN:
+		return "Paging Customer ID length Invalid"
+	case ESME_RINVCITYLEN:
+		return "City Length Invalid"
+	case ESME_RINVSTATELEN:
+		return "State Length Invalid"
+	case ESME_RINVZIPPREFIXLEN:
+		return "Zip Prefix Length Invalid"
+	case ESME_RINVZIPPOSTFIXLEN:
+		return "Zip Postfix Length Invalid"
+	case ESME_RINVMINLEN:
+		return "MIN Length Invalid"
+	case ESME_RINVMIN:
+		return "MIN Invalid (i.e. No such MIN)"
+	case ESME_RINVPINLEN:
+		return "PIN Length Invalid"
+	case ESME_RINVTERMCODELEN:
+		return "Terminal Code Length Invalid"
+	case ESME_RINVCHANNELLEN:
+		return "Channel Length Invalid"
+	case ESME_RINVCOVREGIONLEN:
+		return "Coverage Region Length Invalid"
+	case ESME_RINVCAPCODELEN:
+		return "Cap Code Length Invalid"
+	case ESME_RINVMDTLEN:
+		return "Message delivery time Length Invalid"
+	case ESME_RINVPRIORMSGLEN:
+		return "Priority Message Length Invalid"
+	case ESME_RINVPERMSGLEN:
+		return "Periodic Messages Length Invalid"
+	case ESME_RINVPGALERTLEN:
+		return "Paging Alerts Length Invalid"
+	case ESME_RINVSMUSERLEN:
+		return "int16 Message User Group Length Invalid"
+	case ESME_RINVRTDBLEN:
+		return "Real Time Data broadcasts Length Invalid"
+	case ESME_RINVREGDELLEN:
+		return "Registered Delivery Length Invalid"
+	case ESME_RINVMSGDISTLEN:
+		return "Message Distribution Length Invalid"
+	case ESME_RINVPRIORMSG:
+		return "Priority Message Length Invalid"
+	case ESME_RINVMDT:
+		return "Message delivery time Invalid"
+	case ESME_RINVPERMSG:
+		return "Periodic Messages Invalid"
+	case ESME_RINVMSGDIST:
+		return "Message Distribution Invalid"
+	case ESME_RINVPGALERT:
+		return "Paging Alerts Invalid"
+	case ESME_RINVSMUSER:
+		return "int16 Message User Group Invalid"
+	case ESME_RINVRTDB:
+		return "Real Time Data broadcasts Invalid"
+	case ESME_RINVREGDEL:
+		return "Registered Delivery Invalid"
+	case ESME_RINVOPTPARLEN:
+		return "Invalid Optional Parameter Length"
+	case ESME_RINVOPTPARSTREAM:
+		return "Error in the optional part of the PDU Body."
+	case ESME_ROPTPARNOTALLWD:
+		return "Optional Parameter not allowed"
+	case ESME_RINVPARLEN:
+		return "Invalid Parameter Length."
+	case ESME_RMISSINGOPTPARAM:
+		return "Expected Optional Parameter missing"
+	case ESME_RINVOPTPARAMVAL:
+		return "Invalid Optional Parameter Value"
+	case ESME_RDELIVERYFAILURE:
+		return "Delivery Failure (used for data_sm_resp)"
+	case ESME_RUNKNOWNERR:
+		return "Unknown Error"
+	case ESME_LAST_ERROR:
+		return "The value of the last error code"
+	}
+	return i.String()
+}
+
 func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.


### PR DESCRIPTION
Fixes #94 

* Fake SMSC is now able to return a `ESME_RINVSYSID` when the system_id provided is `invalid` (for testing purpose)
* Add a method `Desc()` to `CommandStatusType`
* Return a specialized error on binding failure that provides the command status