### PR TITLE
Ignore EOF error when unmarshaling submit_sm_resp with no message_id

### DIFF
--- a/pdu/PDU_test.go
+++ b/pdu/PDU_test.go
@@ -15,6 +15,12 @@ func TestParsePDU(t *testing.T) {
 		require.Nil(t, err)
 	})
 
+	t.Run("submit_sm_resp with command_status != 0 ", func(t *testing.T) {
+		buf := NewBuffer(fromHex("00000010800000040000005800000001"))
+		_, err := Parse(buf)
+		require.Nil(t, err)
+	})
+
 	t.Run("eof", func(t *testing.T) {
 		buf := NewBuffer(nil)
 		_, err := Parse(buf)

--- a/pdu/SubmitSMResp.go
+++ b/pdu/SubmitSMResp.go
@@ -1,7 +1,9 @@
 package pdu
 
 import (
+	"errors"
 	"github.com/linxGnu/gosmpp/data"
+	"io"
 )
 
 // SubmitSMResp PDU.
@@ -52,6 +54,9 @@ func (c *SubmitSMResp) Marshal(b *ByteBuffer) {
 func (c *SubmitSMResp) Unmarshal(b *ByteBuffer) error {
 	return c.base.unmarshal(b, func(b *ByteBuffer) (err error) {
 		c.MessageID, err = b.ReadCString()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
 		return
 	})
 }


### PR DESCRIPTION
Fix for #117 and #118 

I don't fully understand the reason behind #113 , but that change is causing issues when submit_sm_resp returns with command_status != 0.  I propose we ignore the io.EOF error when unmarshalling the message_id. 

I also added a test to identify this issue in future.

Reminder, as per the spec: The submit_sm_resp PDU Body is not returned if the command_status field contains a non-zero value.


