### PR TITLE
OnAllPdu users are now able to return a bool to close the bind

### DIFF
--- a/example/transcceiver_with_manual_response/main.go
+++ b/example/transcceiver_with_manual_response/main.go
@@ -74,12 +74,12 @@ func sendingAndReceiveSMS(wg *sync.WaitGroup) {
 
 }
 
-func handlePDU() func(pdu.PDU) pdu.PDU {
-	return func(p pdu.PDU) pdu.PDU {
+func handlePDU() func(pdu.PDU) (pdu.PDU, bool) {
+	return func(p pdu.PDU) (pdu.PDU, bool) {
 		switch pd := p.(type) {
 		case *pdu.Unbind:
 			fmt.Println("Unbind Received")
-			return pd.GetResponse()
+			return pd.GetResponse(), true
 
 		case *pdu.UnbindResp:
 			fmt.Println("UnbindResp Received")
@@ -95,17 +95,17 @@ func handlePDU() func(pdu.PDU) pdu.PDU {
 
 		case *pdu.EnquireLink:
 			fmt.Println("EnquireLink Received")
-			return pd.GetResponse()
+			return pd.GetResponse(), false
 
 		case *pdu.DataSM:
 			fmt.Println("DataSM receiver")
-			return pd.GetResponse()
+			return pd.GetResponse(), false
 
 		case *pdu.DeliverSM:
 			fmt.Println("DeliverSM receiver")
-			return pd.GetResponse()
+			return pd.GetResponse(), false
 		}
-		return nil
+		return nil, false
 	}
 }
 

--- a/pkg.go
+++ b/pkg.go
@@ -53,6 +53,14 @@ type Settings struct {
 	// Will be ignored if OnAllPDU is set
 	OnPDU PDUCallback
 
+	// OnAllPDU handles all received PDU from SMSC.
+	//
+	// This pdu is NOT responded to automatically,
+	// manual response/handling is needed
+	//
+	// User can also decide to close bind by retuning true, default is false
+	OnAllPDU AllPDUCallback
+
 	// OnReceivingError notifies happened error while reading PDU
 	// from SMSC.
 	OnReceivingError ErrorCallback
@@ -65,12 +73,6 @@ type Settings struct {
 
 	// OnClosed notifies `closed` event due to State.
 	OnClosed ClosedCallback
-
-	// OnAllPDU handles all received PDU from SMSC.
-	//
-	// This pdu is NOT responded to automatically,
-	// manual response/handling is needed
-	OnAllPDU func(pdu pdu.PDU) pdu.PDU
 
 	response func(pdu.PDU)
 }

--- a/receivable.go
+++ b/receivable.go
@@ -108,9 +108,12 @@ func (t *receivable) loop() {
 func (t *receivable) handleOrClose(p pdu.PDU) (closing bool) {
 	if p != nil {
 		if t.settings.OnAllPDU != nil {
-			r := t.settings.OnAllPDU(p)
-			if r != nil {
-				t.settings.response(r)
+			response, closeBind := t.settings.OnAllPDU(p)
+			t.settings.response(response)
+			if closeBind {
+				time.Sleep(50 * time.Millisecond)
+				closing = true
+				t.closing(UnbindClosing)
 			}
 			return
 		}

--- a/types.go
+++ b/types.go
@@ -5,6 +5,10 @@ import "github.com/linxGnu/gosmpp/pdu"
 // PDUCallback handles received PDU.
 type PDUCallback func(pdu pdu.PDU, responded bool)
 
+// AllPDUCallback handles received PDU. Return response PDU
+// and close bind option.
+type AllPDUCallback func(pdu pdu.PDU) (pdu.PDU, bool)
+
 // PDUErrorCallback notifies fail-to-submit PDU with along error.
 type PDUErrorCallback func(pdu pdu.PDU, err error)
 


### PR DESCRIPTION
What: 
OnAllPdu setting did not allow users to report bind closing status. This cause an error io error when users responded to a unbind request.

Why:
The change allow users to send back a bool  to let the to close the bind, if needed, like with a unbind request.

How:
The OnAllPDU is called from handleOrClose function, that has a return value to close the bind. The OnAllPdu will now  have a bool return value and that value is forward to the handleorClose function. If the OnCallPdu is returned with a true value, handleOrClose will initiate the close status, like it does without the OnAllPdu setting.

This change also include some other minor changes:
- using a Callback type, to align with existing code
- no need to check if return value of OnAllPDU is nil. Its a struck, it will never be nil and all fields will have default values
- fix manual response example to align with new return bool on OnAllPdu call