### PR TITLE
add a OnRebind callback to notify when rebind was successful

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -72,5 +72,8 @@ type Settings struct {
 	// manual response/handling is needed
 	OnAllPDU func(pdu pdu.PDU) pdu.PDU
 
+	// OnRebind notifies `rebind` event due to State.
+	OnRebind RebindCallback
+
 	response func(pdu.PDU)
 }

--- a/session.go
+++ b/session.go
@@ -119,6 +119,9 @@ func (s *Session) rebind() {
 
 				// reset rebinding state
 				atomic.StoreInt32(&s.rebinding, 0)
+				if s.settings.OnRebind != nil {
+					s.settings.OnRebind()
+				}
 
 				return
 			}

--- a/types.go
+++ b/types.go
@@ -13,3 +13,6 @@ type ErrorCallback func(error)
 
 // ClosedCallback notifies closed event due to State.
 type ClosedCallback func(State)
+
+// RebindCallback notifies rebind event due to State.
+type RebindCallback func()


### PR DESCRIPTION
What: Add callback to notify users when the rebind was successful

Why: As requested in #104, the user sometimes needs to be notified when rebind was successful.

How: Simply add a new callback that is used after the rebind is successful in the rebind func.