### PR TITLE
Add possibility to specify address range when binding with SMSC

### DIFF
--- a/connect_test.go
+++ b/connect_test.go
@@ -1,6 +1,7 @@
 package gosmpp
 
 import (
+	"github.com/linxGnu/gosmpp/pdu"
 	"sync/atomic"
 	"testing"
 
@@ -43,9 +44,22 @@ func TestBindingSMSC(t *testing.T) {
 	t.Run("RX", func(t *testing.T) {
 		checker(t, RXConnector(NonTLSDialer, nextAuth()))
 	})
+	t.Run("RX", func(t *testing.T) {
+		addrRange := pdu.AddressRange{}
+		err := addrRange.SetAddressRange("31218")
+		require.NoError(t, err)
+		checker(t, RXConnector(NonTLSDialer, nextAuth(), WithAddressRange(addrRange)))
+	})
 
 	t.Run("TRX", func(t *testing.T) {
 		checker(t, TRXConnector(NonTLSDialer, nextAuth()))
+	})
+
+	t.Run("TRX", func(t *testing.T) {
+		addrRange := pdu.AddressRange{}
+		err := addrRange.SetAddressRange("31218")
+		require.NoError(t, err)
+		checker(t, TRXConnector(NonTLSDialer, nextAuth(), WithAddressRange(addrRange)))
 	})
 }
 


### PR DESCRIPTION
We're using the lib to connect to SMSC but there was no way to setup the address range parameter within the connector.
We saw that the bindRequest struct was responsible for it and we took the freedom to improve the way we instantiate the connector.
With this pull request you can see that on the Receiver and Transceiver, we can now modify the connector without breaking the public interface of the lib. Which can now be used to add the addressRange option.