### PR TITLE
GSM7BITPACKED related changes and some other fixes around Split/ShouldSplit

### DIFF
--- a/data/7bit.go
+++ b/data/7bit.go
@@ -106,6 +106,23 @@ func ValidateGSM7Buffer(buffer []byte) []byte {
 	return invalidBytes
 }
 
+// GetEscapeChars returns the escape characters in the given text, that doesn't exist in GSM 7-bit DEFAULT alphabet table
+func GetEscapeChars(runeText []rune) []rune {
+	eChars := make([]rune, 0, 4)
+	for _, r := range runeText {
+		if _, ok := forwardEscape[r]; ok {
+			eChars = append(eChars, r)
+		}
+	}
+	return eChars
+}
+
+// IsEscapeChar checks if the given rune is an escape char
+func IsEscapeChar(c rune) bool {
+	_, exists := forwardEscape[c]
+	return exists
+}
+
 // GSM7 returns a GSM 7-bit Bit Encoding.
 //
 // Set the packed flag to true if you wish to convert septets to octets,

--- a/data/codings.go
+++ b/data/codings.go
@@ -93,8 +93,11 @@ func (c *gsm7bit) Decode(data []byte) (string, error) {
 func (c *gsm7bit) DataCoding() byte { return GSM7BITCoding }
 
 func (c *gsm7bit) ShouldSplit(text string, octetLimit uint) (shouldSplit bool) {
-	septetLim := uint(octetLimit * 8 / 7)
-	return uint(len(text)) > septetLim
+	if c.packed {
+		return uint((len(text)*7+7)/8) > octetLimit
+	} else {
+		return uint(len(text)) > octetLimit
+	}
 }
 
 func (c *gsm7bit) EncodeSplit(text string, octetLimit uint) (allSeg [][]byte, err error) {
@@ -104,9 +107,12 @@ func (c *gsm7bit) EncodeSplit(text string, octetLimit uint) (allSeg [][]byte, er
 
 	allSeg = [][]byte{}
 	runeSlice := []rune(text)
-	septetLim := int(octetLimit * 8 / 7)
+	lim := int(octetLimit)
+	if c.packed {
+		lim = int(octetLimit * 8 / 7)
+	}
 
-	fr, to := 0, septetLim
+	fr, to := 0, lim
 	for fr < len(runeSlice) {
 		if to > len(runeSlice) {
 			to = len(runeSlice)
@@ -116,7 +122,7 @@ func (c *gsm7bit) EncodeSplit(text string, octetLimit uint) (allSeg [][]byte, er
 			return nil, err
 		}
 		allSeg = append(allSeg, seg)
-		fr, to = to, to+septetLim
+		fr, to = to, to+lim
 	}
 
 	return

--- a/data/codings.go
+++ b/data/codings.go
@@ -93,11 +93,8 @@ func (c *gsm7bit) Decode(data []byte) (string, error) {
 func (c *gsm7bit) DataCoding() byte { return GSM7BITCoding }
 
 func (c *gsm7bit) ShouldSplit(text string, octetLimit uint) (shouldSplit bool) {
-	if c.packed {
-		return uint((len(text)*7+7)/8) > octetLimit
-	} else {
-		return uint(len(text)) > octetLimit
-	}
+	septetLim := uint(octetLimit * 8 / 7)
+	return uint(len(text)) > septetLim
 }
 
 func (c *gsm7bit) EncodeSplit(text string, octetLimit uint) (allSeg [][]byte, err error) {
@@ -107,8 +104,9 @@ func (c *gsm7bit) EncodeSplit(text string, octetLimit uint) (allSeg [][]byte, er
 
 	allSeg = [][]byte{}
 	runeSlice := []rune(text)
+	septetLim := int(octetLimit * 8 / 7)
 
-	fr, to := 0, int(octetLimit)
+	fr, to := 0, septetLim
 	for fr < len(runeSlice) {
 		if to > len(runeSlice) {
 			to = len(runeSlice)
@@ -118,7 +116,7 @@ func (c *gsm7bit) EncodeSplit(text string, octetLimit uint) (allSeg [][]byte, er
 			return nil, err
 		}
 		allSeg = append(allSeg, seg)
-		fr, to = to, to+int(octetLimit)
+		fr, to = to, to+septetLim
 	}
 
 	return

--- a/data/codings.go
+++ b/data/codings.go
@@ -199,7 +199,8 @@ func shiftBitsLeftOne(input []byte, includeLSB bool) []byte {
 	}
 
 	if includeLSB {
-		shifted = append(shifted, input[len(input)-1]>>7&0x01)
+		lastOctet := (input[len(input)-1] >> 7 & 0x01) | (0x0D << 1) /* https://en.wikipedia.org/wiki/GSM_03.38 Ref tekst: "..When there are 7 spare bits in the last octet of a message..."*/
+		shifted = append(shifted, lastOctet)
 	}
 
 	return shifted

--- a/data/codings_test.go
+++ b/data/codings_test.go
@@ -38,10 +38,29 @@ func testEncodingSplit(t *testing.T, enc EncDec, octetLim uint, original string,
 		require.Equal(t, fromHex(expected[i]), seg)
 		require.LessOrEqualf(t, uint(len(seg)), octetLim,
 			"Segment len must be less than or equal to %d, got %d", octetLim, len(seg))
+
+		if enc == GSM7BITPACKED {
+			seg = shiftBitsOneRight(seg)
+		}
 		decoded, err := enc.Decode(seg)
 		require.Nil(t, err)
 		require.Equal(t, expectDecode[i], decoded)
 	}
+}
+
+func shiftBitsOneRight(input []byte) []byte {
+	carry := byte(0)
+	for i := len(input) - 1; i >= 0; i-- {
+		// Save the carry bit from the previous byte
+		nextCarry := input[i] & 0b00000001
+		// Shift the current byte to the right
+		input[i] >>= 1
+		// Apply the carry from the previous byte to the current byte
+		input[i] |= carry << 7
+		// Update the carry for the next byte
+		carry = nextCarry
+	}
+	return input
 }
 
 func TestCoding(t *testing.T) {
@@ -59,10 +78,8 @@ func TestGSM7Bit(t *testing.T) {
 	testEncoding(t, GSM7BITPACKED, "gjwklgjkwP123+?", "67f57dcd3eabd777684c365bfd00")
 }
 
-func TestSplit(t *testing.T) {
-	require.EqualValues(t, 0o0, GSM7BITPACKED.DataCoding())
-
-	t.Run("testShouldSplitGSM7", func(t *testing.T) {
+func TestShouldSplit(t *testing.T) {
+	t.Run("testShouldSplit_GSM7BIT", func(t *testing.T) {
 		octetLim := uint(140)
 		expect := map[string]bool{
 			"":  false,
@@ -78,22 +95,44 @@ func TestSplit(t *testing.T) {
 		}
 	})
 
-	t.Run("testShouldSplitUCS2", func(t *testing.T) {
+	t.Run("testShouldSplit_UCS2", func(t *testing.T) {
+		octetLim := uint(140)
+		expect := map[string]bool{
+			"":  false,
+			"1": false,
+			"ởỀÊộẩừỰÉÊỗọễệớỡồỰỬỪựởặỬ̀ỵổẤỨợỶẰỢộứẶHữẹ̃ẾỆằỄéậÃỡẰộ̀ỀỗứẲữỪữộÊỵòALữộòC":  false, /* 70 UCS2 chars */
+			"ợÁÊGỷẹííỡỮÂIỆàúễẠỮỊệÂỖÍắẵYẠừẲíộờíẵỠựẤằờởể̃ởỵởềệổồUỡỵầễÁÝởÝNè̉ỚổôỊộợKỨệ́": true,  /* 71 UCS2 chars */
+		}
+
+		splitter, _ := UCS2.(Splitter)
+		for k, v := range expect {
+			ok := splitter.ShouldSplit(k, octetLim)
+			require.Equalf(t, ok, v, "Test case %s", k)
+		}
 	})
 
-	t.Run("testSplitEscapeGSM7", func(t *testing.T) {
-		testEncodingSplit(t, GSM7BITPACKED,
-			134,
-			"gjwklgjkwP123+?sasdasdaqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqdqwdqwDQWdqwdqwdqwdqwwqwdqwdqwddqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqdwqdqwqwdqwdqwqwdqw{",
-			[]string{
-				"67f57dcd3eabd777684c365bfde6e139393c2787e37772fc4e8edfc9f13b397e27c7efe4f89d1cbf93e37772fc4e8edfc9f13b397e27c7efe4f89d1cbf93e377729c1cbf93e37762f44a8edfc9f13b397e27c7eff7f89d1cbf93e37732397e27c7efe4f89d1cbf93e37772fc4e8edfc9f13b397e2703",
-				"f13b397e27c7c9f738397e8fdfc9f13b397e8fdfc9f1fb0605",
-			},
-			[]string{
-				"gjwklgjkwP123+?sasdasdaqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqdqwdqwDQWdqwdqwdqwdqwwqwdqwdqwddqwdqwdqwdqwdqwdqwdqwdqwdqwd",
-				"qwdqwdqdwqdqwqwdqwdqwqwdqw{",
-			})
+	t.Run("testShouldSplit_GSM7BITPACKED", func(t *testing.T) {
+		octetLim := uint(140)
+		expect := map[string]bool{
+			"":  false,
+			"1": false,
+			"12312312311231231231123123123112312312311231231231123123123112312312311231231231123123123112312312311231231231123123123112312312311234121212":                      false,
+			"gjwklgjkwP123+?sasdasdaqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqdqwdqwDQWdqwdqwdqwdqwwqwdqwdqwddqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqdwqdqwqwdqwdqwqwdqw":  false, /* 160 regular basic alphabet chars */
+			"gjwklgjkwP123+?sasdasdaqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqdqwdqwDQWdqwdqwdqwdqwwqwdqwdqwddqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqdwqdqwqwdqwdqwqwdqwd": true,  /* 161 regular basic alphabet chars */
+			"gjwklgjkwP123+?sasdasdaqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqdqwdqwDQWdqwdqwdqwdqwwqwdqwdqwddqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqdwqdqwqwdqwdqwqwdqw{": true,  /* 159 regular basic alphabet chars + 1 escape char at the end */
+			"|}€€|]|€[~€^]€~{~^{|]]|[{|~€^|]^[[{€^]^{€}}^~~]€]~€[€€[]~~[}}]{^}{|}~~]]€^{^|€{^":                                                                                  false, /* 80 escape chars */
+			"|}€€|]|€[~€^]€~{~^{|]]|[{|~€^|]^[[{€^]^{€}}^~~]€]~€[€€[]~~[}}]{^}{|}~~]]€^{^|€{^{":                                                                                 true,  /* 81 escape chars */
+		}
+
+		splitter, _ := GSM7BITPACKED.(Splitter)
+		for k, v := range expect {
+			ok := splitter.ShouldSplit(k, octetLim)
+			require.Equalf(t, ok, v, "Test case %s", k)
+		}
 	})
+}
+func TestSplit(t *testing.T) {
+	require.EqualValues(t, 0o0, GSM7BITPACKED.DataCoding())
 
 	t.Run("testSplitGSM7Empty", func(t *testing.T) {
 		testEncodingSplit(t, GSM7BIT,
@@ -147,6 +186,133 @@ func TestSplit(t *testing.T) {
 			[]string{
 				"biggest gift của Christmas là có nhiều big/challengin",
 				"g",
+			})
+	})
+}
+
+func TestSplit_GSM7BITPACKED(t *testing.T) {
+	require.EqualValues(t, 0o0, GSM7BITPACKED.DataCoding())
+
+	t.Run("testSplit_Escape_GSM7BITPACKED", func(t *testing.T) {
+		testEncodingSplit(t, GSM7BITPACKED,
+			134,
+			"gjwklgjkwP123+?sasdasdaqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqdqwdqwDQWdqwdqwdqwdqwwqwdqwdqwddqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqdwqdqwqwdqwdqwqwdqw{",
+			[]string{
+				"ceeafb9a7d56afefd0986cb6facdc37372784e0ec7efe4f89d1cbf93e37772fc4e8edfc9f13b397e27c7efe4f89d1cbf93e37772fc4e8edfc9f13b397e27c7efe438397e27c7efc4e8951cbf93e37772fc4e8edfeff13b397e27c7ef6472fc4e8edfc9f13b397e27c7efe4f89d1cbf93e37772fc4e8edfc9f13b394ebec7c9f17bfc4e8edfc9",
+				"e2f7f89d1cbf6f50",
+			},
+			[]string{
+				"gjwklgjkwP123+?sasdasdaqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqdqwdqwDQWdqwdqwdqwdqwwqwdqwdqwddqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqwdqdwqdqwqwdqwd",
+				"qwqwdqw{",
+			})
+	})
+
+	/*
+		Total char count = 160,
+		Esc char count = 1,
+		Regular char count = 159,
+		Seg1 => 153->€
+		Expected behaviour: Should not split in the middle of ESC chars
+	*/
+	t.Run("testSplit_EscEndOfSeg1_GSM7BITPACKED", func(t *testing.T) {
+		testEncodingSplit(t, GSM7BITPACKED,
+			134,
+			"pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp€ppppppp",
+			[]string{
+				"e070381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c301",
+				"3665381c0e87c3e1",
+			},
+			[]string{
+				"pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp@",
+				"€ppppppp",
+			})
+	})
+
+	/*
+		Total char count = 160,
+		Esc char count = 2,
+		Regular char count = 158,
+		Seg1 => 152-> ....{
+		Seg2 => 1-> ....{
+		Expected behaviour: Should not split in the middle of ESC chars
+	*/
+	t.Run("testSplit_EscEndOfSeg1AndSeg2_1_GSM7BITPACKED", func(t *testing.T) {
+		testEncodingSplit(t, GSM7BITPACKED,
+			134,
+			"pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp{{pppppppp",
+			[]string{
+				"e070381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0edfa000",
+				"3628381c0e87c3e170",
+			},
+			[]string{
+				"pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp{@",
+				"{pppppppp",
+			})
+	})
+
+	/*
+		Total char count = 160,
+		Esc char count = 2,
+		Regular char count = 158,
+		Seg1 => 152-> ....€
+		Seg2 => 1-> ....€
+		Expected behaviour: Should not split in the middle of ESC chars
+	*/
+	t.Run("testSplit_EscEndOfSeg1AndSeg2_2_GSM7BITPACKED", func(t *testing.T) {
+		testEncodingSplit(t, GSM7BITPACKED,
+			134,
+			"pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp€€pppppppp",
+			[]string{
+				"e070381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0edf9401",
+				"3665381c0e87c3e170",
+			},
+			[]string{
+				"pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp€@",
+				"€pppppppp",
+			})
+	})
+
+	/*
+		Total char count = 162,
+		Esc char count = 0,
+		Regular char count = 162,
+		Seg1 => 153
+		Seg2 => 9
+		Scenario: All charcters in the GSM7Bit Basic Character Set table (non-escape chars) https://en.wikipedia.org/wiki/GSM_03.38
+	*/
+	t.Run("testSplit_AllGSM7BitBasicCharset_GSM7BITPACKED", func(t *testing.T) {
+		testEncodingSplit(t, GSM7BITPACKED,
+			134,
+			"ΩØ;19Ξòå1-¤6aΞΘANanΣ¡>)òΦ3L;aøΛ-o@>I¥1=-ü!N¤&o9Hmda3jΞ@ÅΣlhEE§/:Çù0Θ&:_&Π;KLÅÅ@fÜ-kFH?ΠB5/ÆΓ?55=<Ω¡N2ñ¥*L¤aÖ! ÖΘ+øF£_Ç?øΔΓ-lèòCìnEBmhÉF*<Åi/aΩ¥CDøfGÇ$/=Λ'ÅA3ò#fkù",
+			[]string{
+				"2a8b5d2ca7413c622d922dacc9049d613706e84b212433e62ecca0b4de005f7210ebb5fc2127c9f4ce21dbe4f04cad0138306c74b1f87de9120658c6a48b982cbb25d3e10098bdadb511f9b3086b2fcee457abf57815a053d61fa898a4303704e266560c632092f8312093169b80181edc45611bfd31aa788ef42b5c190c890cf3312178f528",
+				"4e8ee00c3132af0d",
+			},
+			[]string{
+				"ΩØ;19Ξòå1-¤6aΞΘANanΣ¡>)òΦ3L;aøΛ-o@>I¥1=-ü!N¤&o9Hmda3jΞ@ÅΣlhEE§/:Çù0Θ&:_&Π;KLÅÅ@fÜ-kFH?ΠB5/ÆΓ?55=<Ω¡N2ñ¥*L¤aÖ! ÖΘ+øF£_Ç?øΔΓ-lèòCìnEBmhÉF*<Åi/aΩ¥CDøfGÇ$/=Λ",
+				"'ÅA3ò#fkù",
+			})
+	})
+
+	/*
+		Total char count = 81,
+		Esc char count = 81,
+		Regular char count = 0,
+		Seg1 => 153
+		Seg2 => 9
+		Scenario: All charcters in the GSM7Bit Escape Character Set table https://en.wikipedia.org/wiki/GSM_03.38
+	*/
+	t.Run("testSplit_AllGSM7BitBasicCharset_GSM7BITPACKED", func(t *testing.T) {
+		testEncodingSplit(t, GSM7BITPACKED,
+			134,
+			"|{[€|^€[{|€{[|^{~[}€|}|^|^[^]€{[]~}€]{{^|^][€]|€~€^[~}^]{]~{^^€^[~|^]|€~|^€{]{~|}",
+			[]string{
+				"36c00d6ac3db9437c00d6553def036a80d7053dea036bc0d7043d9a036bd0d6f93da9437c04d6a03dc5036c00d65c3db5036be4d7983daf036be4d6f93da9437be0d6a83da5036c00d65e3dbf036e58d6f03dc9437bd4d7943d9f036bd4d6a43d9f836a88d6fd3dba036940d6553de5036bc4d6f03dc5036be0d7053def436c00d6553dea000",
+				"36be0d6ad3db003729",
+			},
+			[]string{
+				"|{[€|^€[{|€{[|^{~[}€|}|^|^[^]€{[]~}€]{{^|^][€]|€~€^[~}^]{]~{^^€^[~|^]|€~|^€{@",
+				"]{~|}",
 			})
 	})
 }

--- a/data/codings_test.go
+++ b/data/codings_test.go
@@ -219,11 +219,11 @@ func TestSplit_GSM7BITPACKED(t *testing.T) {
 			134,
 			"pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp€ppppppp",
 			[]string{
-				"e070381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c301",
+				"e070381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c31b",
 				"3665381c0e87c3e1",
 			},
 			[]string{
-				"pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp@",
+				"pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp\r",
 				"€ppppppp",
 			})
 	})
@@ -241,11 +241,11 @@ func TestSplit_GSM7BITPACKED(t *testing.T) {
 			134,
 			"pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp{{pppppppp",
 			[]string{
-				"e070381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0edfa000",
+				"e070381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0edfa01a",
 				"3628381c0e87c3e170",
 			},
 			[]string{
-				"pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp{@",
+				"pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp{\r",
 				"{pppppppp",
 			})
 	})
@@ -263,11 +263,11 @@ func TestSplit_GSM7BITPACKED(t *testing.T) {
 			134,
 			"pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp€€pppppppp",
 			[]string{
-				"e070381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0edf9401",
+				"e070381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0e87c3e170381c0edf941b",
 				"3665381c0e87c3e170",
 			},
 			[]string{
-				"pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp€@",
+				"pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp€\r",
 				"€pppppppp",
 			})
 	})
@@ -307,11 +307,11 @@ func TestSplit_GSM7BITPACKED(t *testing.T) {
 			134,
 			"|{[€|^€[{|€{[|^{~[}€|}|^|^[^]€{[]~}€]{{^|^][€]|€~€^[~}^]{]~{^^€^[~|^]|€~|^€{]{~|}",
 			[]string{
-				"36c00d6ac3db9437c00d6553def036a80d7053dea036bc0d7043d9a036bd0d6f93da9437c04d6a03dc5036c00d65c3db5036be4d7983daf036be4d6f93da9437be0d6a83da5036c00d65e3dbf036e58d6f03dc9437bd4d7943d9f036bd4d6a43d9f836a88d6fd3dba036940d6553de5036bc4d6f03dc5036be0d7053def436c00d6553dea000",
+				"36c00d6ac3db9437c00d6553def036a80d7053dea036bc0d7043d9a036bd0d6f93da9437c04d6a03dc5036c00d65c3db5036be4d7983daf036be4d6f93da9437be0d6a83da5036c00d65e3dbf036e58d6f03dc9437bd4d7943d9f036bd4d6a43d9f836a88d6fd3dba036940d6553de5036bc4d6f03dc5036be0d7053def436c00d6553dea01a",
 				"36be0d6ad3db003729",
 			},
 			[]string{
-				"|{[€|^€[{|€{[|^{~[}€|}|^|^[^]€{[]~}€]{{^|^][€]|€~€^[~}^]{]~{^^€^[~|^]|€~|^€{@",
+				"|{[€|^€[{|€{[|^{~[}€|}|^|^[^]€{[]~}€]{{^|^][€]|€~€^[~}^]{]~{^^€^[~|^]|€~|^€{\r",
 				"]{~|}",
 			})
 	})

--- a/pdu/ShortMessage.go
+++ b/pdu/ShortMessage.go
@@ -66,6 +66,17 @@ func (c *ShortMessage) SetMessageWithEncoding(message string, enc data.Encoding)
 			c.message = message
 			c.enc = enc
 		}
+
+		if c.enc == data.GSM7BITPACKED { // to prevent unwanted "@"
+			runeSlice := []rune(c.message)
+			tLen := len(runeSlice)
+			escCharsLen := len(data.GetEscapeChars(runeSlice))
+			regCharsLen := tLen - escCharsLen
+			nSeptet := escCharsLen*2 + regCharsLen
+			if (nSeptet+1)%8 == 0 {
+				c.messageData[len(c.messageData)-1] = (c.messageData[len(c.messageData)-1] & 0x01) | (0x0D << 1) /* https://en.wikipedia.org/wiki/GSM_03.38 Ref tekst: "..When there are 7 spare bits in the last octet of a message..."*/
+			}
+		}
 	}
 	return
 }

--- a/pdu/SubmitSM.go
+++ b/pdu/SubmitSM.go
@@ -46,7 +46,13 @@ func NewSubmitSM() PDU {
 // ShouldSplit check if this the user data of submitSM PDU
 func (c *SubmitSM) ShouldSplit() bool {
 	// GSM standard mandates that User Data must be no longer than 140 octet
-	return len(c.Message.messageData) > 140
+	mDataLength := len(c.Message.messageData)
+	if c.Message.enc == data.GSM7BIT {
+		septetLim := data.SM_GSM_MSG_LEN * 8 / 7
+		return uint(mDataLength) > uint(septetLim)
+	}
+
+	return mDataLength > data.SM_GSM_MSG_LEN
 }
 
 // CanResponse implements PDU interface.

--- a/pdu/SubmitSM.go
+++ b/pdu/SubmitSM.go
@@ -46,13 +46,7 @@ func NewSubmitSM() PDU {
 // ShouldSplit check if this the user data of submitSM PDU
 func (c *SubmitSM) ShouldSplit() bool {
 	// GSM standard mandates that User Data must be no longer than 140 octet
-	mDataLength := len(c.Message.messageData)
-	if c.Message.enc == data.GSM7BIT {
-		septetLim := data.SM_GSM_MSG_LEN * 8 / 7
-		return uint(mDataLength) > uint(septetLim)
-	}
-
-	return mDataLength > data.SM_GSM_MSG_LEN
+	return len(c.Message.messageData) > data.SM_GSM_MSG_LEN
 }
 
 // CanResponse implements PDU interface.

--- a/pdu/SubmitSM.go
+++ b/pdu/SubmitSM.go
@@ -71,13 +71,18 @@ func (c *SubmitSM) Split() (multiSubSM []*SubmitSM, err error) {
 		return
 	}
 
+	esmClass := c.EsmClass // no need to "or" with SM_UDH_GSM when a message has a single part
+	if len(multiMsg) > 1 {
+		esmClass = c.EsmClass | data.SM_UDH_GSM // must set to indicate UDH
+	}
+
 	for _, msg := range multiMsg {
 		multiSubSM = append(multiSubSM, &SubmitSM{
 			base:                 c.base,
 			ServiceType:          c.ServiceType,
 			SourceAddr:           c.SourceAddr,
 			DestAddr:             c.DestAddr,
-			EsmClass:             c.EsmClass | data.SM_UDH_GSM, // must set to indicate UDH
+			EsmClass:             esmClass,
 			ProtocolID:           c.ProtocolID,
 			PriorityFlag:         c.PriorityFlag,
 			ScheduleDeliveryTime: c.ScheduleDeliveryTime,

--- a/pdu/UDH.go
+++ b/pdu/UDH.go
@@ -184,7 +184,8 @@ func NewIEConcatMessage(totalParts, partNum, mref byte) InfoElement {
 
 // UnmarshalBinary unmarshal IE from binary in src, only read a single IE,
 // expect src at least of length 2 with correct IE format:
-//		[ ID_1, LENGTH_1, DATA_N ]
+//
+//	[ ID_1, LENGTH_1, DATA_N ]
 func (ie *InfoElement) UnmarshalBinary(src []byte) (int, error) {
 	if len(src) < 2 {
 		return 0, fmt.Errorf("decode error InfoElement underflow, len = %d", len(src))


### PR DESCRIPTION
 1. GSM7BITPACKED - Changes about adding a padding bit to the beginning of the septets just after UDH during EncodeSplit
   **Ref1:** https://www.etsi.org/deliver/etsi_ts/123000_123099/123040/16.00.00_60/ts_123040v160000p.pdf Page 74
   **Ref2:** https://help.goacoustic.com/hc/en-us/articles/360043843154--How-character-encoding-affects-SMS-message-length Pls. ref. to the note "..It is added as padding so that the actual 7-bit encoding data begins on a septet boundary—the 50th bit."
   **Ref3:** https://en.wikipedia.org/wiki/Concatenated_SMS "..This means up to 6 bits of zeros need to be inserted at the start of the [message]."

2. Handling escape chars during Split/ShouldSplit
   Esacpe characters occupy 2 octets/septets
   **Ref1:** https://en.wikipedia.org/wiki/GSM_03.38
   **Ref2:** https://www.developershome.com/sms/gsmAlphabet.asp

3. Fix for UCS2-> ShouldSplit where the first segment should be split just after 70 UCS2 chars (rune check, pls see unit tests), but the next after 67 chars.

4. Fix for EsmClass when Split returns a single part

