### PR TITLE
Add the possibility to change the addressRange maxLen with options.

### DIFF
--- a/connect_test.go
+++ b/connect_test.go
@@ -46,8 +46,7 @@ func TestBindingSMSC(t *testing.T) {
 	})
 	t.Run("RX", func(t *testing.T) {
 		addrRange := pdu.AddressRange{}
-		err := addrRange.SetAddressRange("31218")
-		require.NoError(t, err)
+		addrRange.AddressRange = "31218"
 		checker(t, RXConnector(NonTLSDialer, nextAuth(), WithAddressRange(addrRange)))
 	})
 
@@ -57,8 +56,7 @@ func TestBindingSMSC(t *testing.T) {
 
 	t.Run("TRX", func(t *testing.T) {
 		addrRange := pdu.AddressRange{}
-		err := addrRange.SetAddressRange("31218")
-		require.NoError(t, err)
+		addrRange.AddressRange = "31218"
 		checker(t, TRXConnector(NonTLSDialer, nextAuth(), WithAddressRange(addrRange)))
 	})
 }

--- a/pdu/AddressRange.go
+++ b/pdu/AddressRange.go
@@ -1,47 +1,43 @@
 package pdu
 
-import (
-	"fmt"
-
-	"github.com/linxGnu/gosmpp/data"
-)
+import "github.com/linxGnu/gosmpp/data"
 
 // AddressRange smpp address range of src and dst.
 type AddressRange struct {
-	ton          byte
-	npi          byte
-	addressRange string
+	Ton          byte
+	Npi          byte
+	AddressRange string
 }
 
 // NewAddressRange create new AddressRange with default max length.
 func NewAddressRange() AddressRange {
-	return AddressRange{ton: data.GetDefaultTon(), npi: data.GetDefaultNpi()}
+	return AddressRange{Ton: data.GetDefaultTon(), Npi: data.GetDefaultNpi()}
 }
 
 // NewAddressRangeWithAddr create new AddressRange.
 func NewAddressRangeWithAddr(addr string) (a AddressRange, err error) {
 	a = NewAddressRange()
-	err = a.SetAddressRange(addr)
+	a.AddressRange = addr
 	return
 }
 
 // NewAddressRangeWithTonNpi create new AddressRange with ton, npi.
 func NewAddressRangeWithTonNpi(ton, npi byte) AddressRange {
-	return AddressRange{ton: ton, npi: npi}
+	return AddressRange{Ton: ton, Npi: npi}
 }
 
 // NewAddressRangeWithTonNpiAddr returns new address with ton, npi, addr string.
 func NewAddressRangeWithTonNpiAddr(ton, npi byte, addr string) (a AddressRange, err error) {
 	a = NewAddressRangeWithTonNpi(ton, npi)
-	err = a.SetAddressRange(addr)
+	a.AddressRange = addr
 	return
 }
 
 // Unmarshal from buffer.
 func (c *AddressRange) Unmarshal(b *ByteBuffer) (err error) {
-	if c.ton, err = b.ReadByte(); err == nil {
-		if c.npi, err = b.ReadByte(); err == nil {
-			c.addressRange, err = b.ReadCString()
+	if c.Ton, err = b.ReadByte(); err == nil {
+		if c.Npi, err = b.ReadByte(); err == nil {
+			c.AddressRange, err = b.ReadCString()
 		}
 	}
 	return
@@ -49,44 +45,9 @@ func (c *AddressRange) Unmarshal(b *ByteBuffer) (err error) {
 
 // Marshal to buffer.
 func (c *AddressRange) Marshal(b *ByteBuffer) {
-	b.Grow(3 + len(c.addressRange))
+	b.Grow(3 + len(c.AddressRange))
 
-	_ = b.WriteByte(c.ton)
-	_ = b.WriteByte(c.npi)
-	_ = b.WriteCString(c.addressRange)
-}
-
-// SetAddressRange sets address range.
-func (c *AddressRange) SetAddressRange(addr string) (err error) {
-	if len(addr) > data.SM_ADDR_RANGE_LEN {
-		err = fmt.Errorf("Address len exceed limit. (%d > %d)", len(addr), data.SM_ADDR_RANGE_LEN)
-	} else {
-		c.addressRange = addr
-	}
-	return
-}
-
-// SetTon sets ton.
-func (c *AddressRange) SetTon(ton byte) {
-	c.ton = ton
-}
-
-// SetNpi sets npi.
-func (c *AddressRange) SetNpi(npi byte) {
-	c.npi = npi
-}
-
-// AddressRange returns assigned address range (in string).
-func (c *AddressRange) AddressRange() string {
-	return c.addressRange
-}
-
-// Ton returns assigned ton.
-func (c *AddressRange) Ton() byte {
-	return c.ton
-}
-
-// Npi returns assigned npi.
-func (c *AddressRange) Npi() byte {
-	return c.npi
+	_ = b.WriteByte(c.Ton)
+	_ = b.WriteByte(c.Npi)
+	_ = b.WriteCString(c.AddressRange)
 }

--- a/pdu/AddressRange_test.go
+++ b/pdu/AddressRange_test.go
@@ -9,37 +9,29 @@ import (
 func TestAddressRange(t *testing.T) {
 	t.Run("new", func(t *testing.T) {
 		a, err := NewAddressRangeWithAddr("abc")
-		require.Nil(t, err)
-		require.Equal(t, "abc", a.AddressRange())
+		require.NoError(t, err)
+		require.Equal(t, "abc", a.AddressRange)
 	})
 
 	t.Run("newWithAddr", func(t *testing.T) {
 		_, err := NewAddressRangeWithAddr("12345678901234567890121234567890123456789012")
-		require.NotNil(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("newTonNpi", func(t *testing.T) {
 		a := NewAddressRangeWithTonNpi(3, 7)
-		require.Nil(t, a.SetAddressRange("123456789"))
-		require.EqualValues(t, 3, a.Ton())
-		require.EqualValues(t, 7, a.Npi())
-		require.Equal(t, "123456789", a.AddressRange())
-		a.SetTon(11)
-		a.SetNpi(19)
-		require.EqualValues(t, 11, a.Ton())
-		require.EqualValues(t, 19, a.Npi())
+		a.AddressRange = "123456789"
+		require.EqualValues(t, 3, a.Ton)
+		require.EqualValues(t, 7, a.Npi)
+		require.Equal(t, "123456789", a.AddressRange)
 	})
 
 	t.Run("newTonNpiAddr", func(t *testing.T) {
 		a, err := NewAddressRangeWithTonNpiAddr(3, 7, "123456789")
-		require.Nil(t, err)
-		require.EqualValues(t, 3, a.Ton())
-		require.EqualValues(t, 7, a.Npi())
-		require.Equal(t, "123456789", a.AddressRange())
-		a.SetTon(11)
-		a.SetNpi(19)
-		require.EqualValues(t, 11, a.Ton())
-		require.EqualValues(t, 19, a.Npi())
+		require.NoError(t, err)
+		require.EqualValues(t, 3, a.Ton)
+		require.EqualValues(t, 7, a.Npi)
+		require.Equal(t, "123456789", a.AddressRange)
 	})
 
 	t.Run("unmarshal", func(t *testing.T) {
@@ -47,16 +39,16 @@ func TestAddressRange(t *testing.T) {
 		var a AddressRange
 		require.Nil(t, a.Unmarshal(buf))
 		require.Zero(t, buf.Len())
-		require.Equal(t, "phantomStrike", a.AddressRange())
-		require.EqualValues(t, 49, a.Ton())
-		require.EqualValues(t, 91, a.Npi())
+		require.Equal(t, "phantomStrike", a.AddressRange)
+		require.EqualValues(t, 49, a.Ton)
+		require.EqualValues(t, 91, a.Npi)
 	})
 
 	t.Run("marshal", func(t *testing.T) {
-		a, err := NewAddressRangeWithAddr("phantomOpera")
-		require.Nil(t, err)
-		a.SetTon(95)
-		a.SetNpi(13)
+		a := AddressRange{}
+		a.AddressRange = "phantomOpera"
+		a.Ton = 95
+		a.Npi = 13
 
 		buf := NewBuffer(nil)
 		a.Marshal(buf)

--- a/pdu/BindRequest.go
+++ b/pdu/BindRequest.go
@@ -35,7 +35,7 @@ func NewBindRequest(t BindingType) (b *BindRequest) {
 		SystemID:         data.DFLT_SYSID,
 		Password:         data.DFLT_PASS,
 		SystemType:       data.DFLT_SYSTYPE,
-		AddressRange:     NewAddressRange(),
+		AddressRange:     AddressRange{},
 		InterfaceVersion: data.SMPP_V34,
 	}
 

--- a/pdu/BindRequest_test.go
+++ b/pdu/BindRequest_test.go
@@ -20,9 +20,9 @@ func TestBindRequest(t *testing.T) {
 		req.Password = "password"
 		req.SystemType = "only"
 		req.InterfaceVersion = 44
-		require.Nil(t, req.AddressRange.SetAddressRange("emptY"))
-		req.AddressRange.SetTon(23)
-		req.AddressRange.SetNpi(101)
+		req.AddressRange.AddressRange = "emptY"
+		req.AddressRange.Ton = 23
+		req.AddressRange.Npi = 101
 
 		validate(t,
 			req,
@@ -42,7 +42,9 @@ func TestBindRequest(t *testing.T) {
 		req.Password = "password"
 		req.SystemType = "only"
 		req.InterfaceVersion = 44
-		req.AddressRange, _ = NewAddressRangeWithTonNpiAddr(23, 101, "emptY")
+		req.AddressRange.AddressRange = "emptY"
+		req.AddressRange.Ton = 23
+		req.AddressRange.Npi = 101
 
 		validate(t,
 			req,
@@ -62,9 +64,9 @@ func TestBindRequest(t *testing.T) {
 		req.Password = "password"
 		req.SystemType = "only"
 		req.InterfaceVersion = 44
-		require.Nil(t, req.AddressRange.SetAddressRange("emptY"))
-		req.AddressRange.SetTon(23)
-		req.AddressRange.SetNpi(101)
+		req.AddressRange.AddressRange = "emptY"
+		req.AddressRange.Ton = 23
+		req.AddressRange.Npi = 101
 
 		validate(t,
 			req,


### PR DESCRIPTION
Hello, we have a national service provider that use a custom protocol based on SMPP.
We need to have the possibility to set the max length for the address range.

I made the change using the option pattern (like the change on the connector to inject the address range)
This way we open the lib but do not break the public interface.