### PR TITLE
Fix issue #151: bind not restarting when user uses closeBind

### DIFF
--- a/receivable.go
+++ b/receivable.go
@@ -97,7 +97,7 @@ func (t *receivable) loop() {
 			p, err = pdu.Parse(t.conn)
 		}
 		closeOnError := t.check(err)
-		if closeOnError {
+		if closeOnError && atomic.LoadInt32(&t.aliveState) == Alive {
 			t.closing(InvalidStreaming)
 			return
 		}

--- a/transceivable.go
+++ b/transceivable.go
@@ -191,5 +191,4 @@ func (t *transceivable) closing(state State) {
 		}
 		t.wg.Wait()
 	}
-	return
 }

--- a/transceivable.go
+++ b/transceivable.go
@@ -163,8 +163,7 @@ func (t *transceivable) windowCleanup() {
 				if time.Since(request.TimeSent) > t.settings.PduExpireTimeOut {
 					_ = t.requestStore.Delete(ctx, request.GetSequenceNumber())
 					if t.settings.OnExpiredPduRequest != nil {
-						bindClose := t.settings.OnExpiredPduRequest(request.PDU)
-						if bindClose && atomic.LoadInt32(&t.aliveState) == Alive {
+						if t.settings.OnExpiredPduRequest(request.PDU) {
 							t.closing(ConnectionIssue)
 						}
 					}

--- a/transceivable.go
+++ b/transceivable.go
@@ -164,7 +164,7 @@ func (t *transceivable) windowCleanup() {
 					_ = t.requestStore.Delete(ctx, request.GetSequenceNumber())
 					if t.settings.OnExpiredPduRequest != nil {
 						bindClose := t.settings.OnExpiredPduRequest(request.PDU)
-						if bindClose {
+						if bindClose && atomic.LoadInt32(&t.aliveState) == Alive {
 							t.closing(ConnectionIssue)
 						}
 					}

--- a/transceivable.go
+++ b/transceivable.go
@@ -177,6 +177,8 @@ func (t *transceivable) windowCleanup() {
 
 func (t *transceivable) closing(state State) {
 	if atomic.CompareAndSwapInt32(&t.aliveState, Alive, Closed) {
+		t.cancel()
+
 		t.in.closing(StoppingProcessOnly)
 		t.out.closing(StoppingProcessOnly)
 
@@ -187,6 +189,7 @@ func (t *transceivable) closing(state State) {
 		if t.settings.OnClosed != nil {
 			t.settings.OnClosed(state)
 		}
+		t.wg.Wait()
 	}
 	return
 }


### PR DESCRIPTION
When a pdu expires and the user  returns true on closeBind, it should now call the close function with the proper state. This will allow OnClosed to be called and the bind to be restarted.

This also fixes the the transceiver context that is never closed.