### PR TITLE
Multiple Bug Fixes 

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -118,10 +118,10 @@ type WindowedRequestTracking struct {
 	// OnClosePduRequest will return all PDU request found in the store when the bind closes
 	OnClosePduRequest func(pdu.PDU)
 
-	// Set the number of second to expire a request sent to the SMSC
+	// Set the time duration to expire a request sent to the SMSC
 	//
 	// Zero duration disables pdu expire check and the cache may fill up over time with expired PDU request
-	// Recommended: eual or less to the value set in ReadTimeout + EnquireLink
+	// Recommended: equal or less to the value set in ReadTimeout + EnquireLink
 	PduExpireTimeOut time.Duration
 
 	// The time period between each check of the expired PDU in the cache
@@ -139,9 +139,9 @@ type WindowedRequestTracking struct {
 	// if enabled, EnquireLink and Unbind request will be responded to automatically
 	EnableAutoRespond bool
 
-	// Set the number of millisecond to expire a request to store or retrieve data from request store
+	// Set the time period to expire a request to store or retrieve data from request store
 	//
 	// Value must be greater than 0
-	// 200 to 1000 is a good starting point
+	// 200 to 1000 milliseconds is a good starting point
 	StoreAccessTimeOut time.Duration
 }

--- a/receivable.go
+++ b/receivable.go
@@ -113,7 +113,7 @@ func (rx *receivable) handleWindowPdu(p pdu.PDU) (closing bool) {
 			*pdu.SubmitMultiResp,
 			*pdu.SubmitSMResp:
 			if rx.settings.OnExpectedPduResponse != nil {
-				ctx, cancelFunc := context.WithTimeout(context.Background(), rx.settings.StoreAccessTimeOut*time.Millisecond)
+				ctx, cancelFunc := context.WithTimeout(context.Background(), rx.settings.StoreAccessTimeOut)
 				defer cancelFunc()
 				request, ok := rx.requestStore.Get(ctx, p.GetSequenceNumber())
 				if ok {

--- a/receivable.go
+++ b/receivable.go
@@ -20,97 +20,97 @@ type receivable struct {
 }
 
 func newReceivable(conn *Connection, settings Settings, requestStore RequestStore) *receivable {
-	r := &receivable{
+	rx := &receivable{
 		settings:     settings,
 		conn:         conn,
 		requestStore: requestStore,
 	}
-	r.ctx, r.cancel = context.WithCancel(context.Background())
+	rx.ctx, rx.cancel = context.WithCancel(context.Background())
 
-	return r
+	return rx
 }
 
-func (t *receivable) close(state State) (err error) {
-	if atomic.CompareAndSwapInt32(&t.aliveState, Alive, Closed) {
+func (rx *receivable) close(state State) (err error) {
+	if atomic.CompareAndSwapInt32(&rx.aliveState, Alive, Closed) {
 		// cancel to notify stop
-		t.cancel()
+		rx.cancel()
 
 		// set read deadline for current blocking read
-		_ = t.conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+		_ = rx.conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
 
 		// wait daemons
-		t.wg.Wait()
+		rx.wg.Wait()
 
 		// close connection to notify daemons to stop
 		if state != StoppingProcessOnly {
-			err = t.conn.Close()
+			err = rx.conn.Close()
 		}
 
 		// notify receiver closed
-		if t.settings.OnClosed != nil {
-			t.settings.OnClosed(state)
+		if rx.settings.OnClosed != nil {
+			rx.settings.OnClosed(state)
 		}
 	}
 	return
 }
 
-func (t *receivable) closing(state State) {
+func (rx *receivable) closing(state State) {
 	go func() {
-		_ = t.close(state)
+		_ = rx.close(state)
 	}()
 }
 
-func (t *receivable) start() {
-	t.wg.Add(1)
+func (rx *receivable) start() {
+	rx.wg.Add(1)
 	go func() {
-		defer t.wg.Done()
-		t.loop()
+		defer rx.wg.Done()
+		rx.loop()
 	}()
 }
 
-func (t *receivable) loop() {
+func (rx *receivable) loop() {
 	var err error
 	for {
 		select {
-		case <-t.ctx.Done():
+		case <-rx.ctx.Done():
 			return
 		default:
 		}
 
 		// read pdu from conn
 		var p pdu.PDU
-		if err = t.conn.SetReadTimeout(t.settings.ReadTimeout); err == nil {
-			p, err = pdu.Parse(t.conn)
+		if err = rx.conn.SetReadTimeout(rx.settings.ReadTimeout); err == nil {
+			p, err = pdu.Parse(rx.conn)
 		}
 		if err != nil {
-			if atomic.LoadInt32(&t.aliveState) == Alive {
-				if t.settings.OnReceivingError != nil {
-					t.settings.OnReceivingError(err)
+			if atomic.LoadInt32(&rx.aliveState) == Alive {
+				if rx.settings.OnReceivingError != nil {
+					rx.settings.OnReceivingError(err)
 				}
-				t.closing(InvalidStreaming)
+				rx.closing(InvalidStreaming)
 			}
 			return
 		}
 
 		var closeOnUnbind bool
 		if p != nil {
-			if t.settings.WindowedRequestTracking != nil && t.settings.OnExpectedPduResponse != nil {
-				closeOnUnbind = t.handleWindowPdu(p)
-			} else if t.settings.OnAllPDU != nil {
-				closeOnUnbind = t.handleAllPdu(p)
+			if rx.settings.WindowedRequestTracking != nil && rx.settings.OnExpectedPduResponse != nil {
+				closeOnUnbind = rx.handleWindowPdu(p)
+			} else if rx.settings.OnAllPDU != nil {
+				closeOnUnbind = rx.handleAllPdu(p)
 			} else {
-				closeOnUnbind = t.handleOrClose(p)
+				closeOnUnbind = rx.handleOrClose(p)
 			}
 			if closeOnUnbind {
-				t.closing(UnbindClosing)
+				rx.closing(UnbindClosing)
 			}
 		}
 
 	}
 }
 
-func (t *receivable) handleWindowPdu(p pdu.PDU) (closing bool) {
-	if t.settings.WindowedRequestTracking != nil && t.settings.OnExpectedPduResponse != nil && p != nil {
+func (rx *receivable) handleWindowPdu(p pdu.PDU) (closing bool) {
+	if rx.settings.WindowedRequestTracking != nil && rx.settings.OnExpectedPduResponse != nil && p != nil {
 		// This case must match the same request item list in transmittable write func
 		switch pp := p.(type) {
 		case *pdu.CancelSMResp,
@@ -121,48 +121,48 @@ func (t *receivable) handleWindowPdu(p pdu.PDU) (closing bool) {
 			*pdu.ReplaceSMResp,
 			*pdu.SubmitMultiResp,
 			*pdu.SubmitSMResp:
-			if t.settings.OnExpectedPduResponse != nil {
-				ctx, cancelFunc := context.WithTimeout(context.Background(), t.settings.StoreAccessTimeOut*time.Millisecond)
+			if rx.settings.OnExpectedPduResponse != nil {
+				ctx, cancelFunc := context.WithTimeout(context.Background(), rx.settings.StoreAccessTimeOut*time.Millisecond)
 				defer cancelFunc()
-				request, ok := t.requestStore.Get(ctx, p.GetSequenceNumber())
+				request, ok := rx.requestStore.Get(ctx, p.GetSequenceNumber())
 				if ok {
-					_ = t.requestStore.Delete(ctx, p.GetSequenceNumber())
+					_ = rx.requestStore.Delete(ctx, p.GetSequenceNumber())
 					response := Response{
 						PDU:             p,
 						OriginalRequest: request,
 					}
-					t.settings.OnExpectedPduResponse(response)
-				} else if t.settings.OnUnexpectedPduResponse != nil {
-					t.settings.OnUnexpectedPduResponse(p)
+					rx.settings.OnExpectedPduResponse(response)
+				} else if rx.settings.OnUnexpectedPduResponse != nil {
+					rx.settings.OnUnexpectedPduResponse(p)
 				}
 			}
 		case *pdu.EnquireLink:
-			if t.settings.EnableAutoRespond {
-				t.settings.response(pp.GetResponse())
-			} else if t.settings.OnReceivedPduRequest != nil {
-				r, _ := t.settings.OnReceivedPduRequest(p)
-				t.settings.response(r)
+			if rx.settings.EnableAutoRespond {
+				rx.settings.response(pp.GetResponse())
+			} else if rx.settings.OnReceivedPduRequest != nil {
+				r, _ := rx.settings.OnReceivedPduRequest(p)
+				rx.settings.response(r)
 
 			}
 		case *pdu.Unbind:
-			if t.settings.EnableAutoRespond {
-				t.settings.response(pp.GetResponse())
+			if rx.settings.EnableAutoRespond {
+				rx.settings.response(pp.GetResponse())
 
 				// wait to send response before closing
 				time.Sleep(50 * time.Millisecond)
 				closing = true
-			} else if t.settings.OnReceivedPduRequest != nil {
-				r, closeBind := t.settings.OnReceivedPduRequest(p)
-				t.settings.response(r)
+			} else if rx.settings.OnReceivedPduRequest != nil {
+				r, closeBind := rx.settings.OnReceivedPduRequest(p)
+				rx.settings.response(r)
 				if closeBind {
 					time.Sleep(50 * time.Millisecond)
 					closing = true
 				}
 			}
 		default:
-			if t.settings.OnReceivedPduRequest != nil {
-				r, closeBind := t.settings.OnReceivedPduRequest(p)
-				t.settings.response(r)
+			if rx.settings.OnReceivedPduRequest != nil {
+				r, closeBind := rx.settings.OnReceivedPduRequest(p)
+				rx.settings.response(r)
 				if closeBind {
 					time.Sleep(50 * time.Millisecond)
 					closing = true
@@ -173,10 +173,10 @@ func (t *receivable) handleWindowPdu(p pdu.PDU) (closing bool) {
 	return
 }
 
-func (t *receivable) handleAllPdu(p pdu.PDU) (closing bool) {
-	if t.settings.OnAllPDU != nil && p != nil {
-		r, closeBind := t.settings.OnAllPDU(p)
-		t.settings.response(r)
+func (rx *receivable) handleAllPdu(p pdu.PDU) (closing bool) {
+	if rx.settings.OnAllPDU != nil && p != nil {
+		r, closeBind := rx.settings.OnAllPDU(p)
+		rx.settings.response(r)
 		if closeBind {
 			time.Sleep(50 * time.Millisecond)
 			closing = true
@@ -185,14 +185,14 @@ func (t *receivable) handleAllPdu(p pdu.PDU) (closing bool) {
 	return
 }
 
-func (t *receivable) handleOrClose(p pdu.PDU) (closing bool) {
+func (rx *receivable) handleOrClose(p pdu.PDU) (closing bool) {
 	if p != nil {
 		switch pp := p.(type) {
 		case *pdu.EnquireLink:
-			t.settings.response(pp.GetResponse())
+			rx.settings.response(pp.GetResponse())
 
 		case *pdu.Unbind:
-			t.settings.response(pp.GetResponse())
+			rx.settings.response(pp.GetResponse())
 			// wait to send response before closing
 			time.Sleep(50 * time.Millisecond)
 
@@ -201,12 +201,12 @@ func (t *receivable) handleOrClose(p pdu.PDU) (closing bool) {
 		default:
 			var responded bool
 			if p.CanResponse() {
-				t.settings.response(p.GetResponse())
+				rx.settings.response(p.GetResponse())
 				responded = true
 			}
 
-			if t.settings.OnPDU != nil {
-				t.settings.OnPDU(p, responded)
+			if rx.settings.OnPDU != nil {
+				rx.settings.OnPDU(p, responded)
 			}
 		}
 	}

--- a/session.go
+++ b/session.go
@@ -77,16 +77,13 @@ func NewSession(c Connector, settings Settings, rebindingInterval time.Duration,
 		if rebindingInterval > 0 {
 			newSettings := settings
 			newSettings.OnClosed = func(state State) {
-				switch state {
-				case ExplicitClosing:
+				if state == ExplicitClosing {
 					return
-
-				default:
-					if session.originalOnClosed != nil {
-						session.originalOnClosed(state)
-					}
-					session.rebind()
 				}
+				if session.originalOnClosed != nil {
+					session.originalOnClosed(state)
+				}
+				session.rebind()
 			}
 			session.settings = newSettings
 		} else {

--- a/session.go
+++ b/session.go
@@ -152,7 +152,6 @@ func (s *Session) close() (err error) {
 
 func (s *Session) rebind() {
 	if atomic.CompareAndSwapInt32(&s.rebinding, 0, 1) {
-		_ = s.close()
 
 		for atomic.LoadInt32(&s.state) == Alive {
 			conn, err := s.c.Connect()

--- a/session_test.go
+++ b/session_test.go
@@ -36,7 +36,7 @@ func TestGetWindowSize(t *testing.T) {
 			WindowedRequestTracking: &WindowedRequestTracking{
 				OnReceivedPduRequest: handleReceivedPduRequest(t),
 				MaxWindowSize:        10,
-				StoreAccessTimeOut:   100,
+				StoreAccessTimeOut:   100 * time.Millisecond,
 			},
 		}, 2*time.Second)
 	require.Nil(t, err)
@@ -57,7 +57,7 @@ func TestGetWindowSize(t *testing.T) {
 			WindowedRequestTracking: &WindowedRequestTracking{
 				OnReceivedPduRequest: handleReceivedPduRequest(t),
 				MaxWindowSize:        10,
-				StoreAccessTimeOut:   100,
+				StoreAccessTimeOut:   100 * time.Millisecond,
 			},
 		}, 2*time.Second)
 	require.Nil(t, err)
@@ -77,7 +77,7 @@ func TestGetWindowSize(t *testing.T) {
 			ReadTimeout: 10 * time.Second,
 			WindowedRequestTracking: &WindowedRequestTracking{
 				MaxWindowSize:      10,
-				StoreAccessTimeOut: 100,
+				StoreAccessTimeOut: 100 * time.Millisecond,
 			},
 		}, 2*time.Second)
 	require.NoError(t, err)
@@ -96,10 +96,10 @@ func TestGetWindowSize(t *testing.T) {
 			EnquireLink: 5 * time.Second,
 			ReadTimeout: 10 * time.Second,
 			WindowedRequestTracking: &WindowedRequestTracking{
-				ExpireCheckTimer:   5,
-				PduExpireTimeOut:   10,
+				ExpireCheckTimer:   5 * time.Second,
+				PduExpireTimeOut:   10 * time.Second,
 				MaxWindowSize:      10,
-				StoreAccessTimeOut: 100,
+				StoreAccessTimeOut: 100 * time.Millisecond,
 			},
 		}, 2*time.Second)
 	require.NoError(t, err)

--- a/state.go
+++ b/state.go
@@ -11,6 +11,8 @@ type State byte
 const (
 	// ExplicitClosing indicates that Transmitter/Receiver/Transceiver is closed
 	// explicitly (from outside).
+	//
+	// This state will not call OnClosed function in the settings
 	ExplicitClosing State = iota
 
 	// StoppingProcessOnly stops daemons but does not close underlying net conn.
@@ -29,6 +31,9 @@ const (
 
 	// UnbindClosing indicates Receiver got unbind request from SMSC and closed due to this request.
 	UnbindClosing
+
+	// RequestExpired indicates the bind was closed because a request expired, usually means bind might be stale
+	RequestExpired
 )
 
 // String interface.
@@ -48,6 +53,9 @@ func (s *State) String() string {
 
 	case UnbindClosing:
 		return "UnbindClosing"
+
+	case RequestExpired:
+		return "RequestExpired"
 
 	default:
 		return ""

--- a/state.go
+++ b/state.go
@@ -32,8 +32,8 @@ const (
 	// UnbindClosing indicates Receiver got unbind request from SMSC and closed due to this request.
 	UnbindClosing
 
-	// RequestExpired indicates the bind was closed because a request expired, usually means bind might be stale
-	RequestExpired
+	// ExpiredRequestClosing indicates the bind was closed because a request expired, usually means bind might be stale
+	ExpiredRequestClosing
 )
 
 // String interface.
@@ -54,8 +54,8 @@ func (s *State) String() string {
 	case UnbindClosing:
 		return "UnbindClosing"
 
-	case RequestExpired:
-		return "RequestExpired"
+	case ExpiredRequestClosing:
+		return "ExpiredRequestClosing"
 
 	default:
 		return ""

--- a/transceivable.go
+++ b/transceivable.go
@@ -105,7 +105,7 @@ func (trx *transceivable) Submit(p pdu.PDU) error {
 
 func (trx *transceivable) GetWindowSize() (int, error) {
 	if trx.settings.WindowedRequestTracking != nil {
-		ctx, cancelFunc := context.WithTimeout(context.Background(), trx.settings.StoreAccessTimeOut*time.Millisecond)
+		ctx, cancelFunc := context.WithTimeout(context.Background(), trx.settings.StoreAccessTimeOut)
 		defer cancelFunc()
 		return trx.requestStore.Length(ctx)
 	}
@@ -122,7 +122,7 @@ func (trx *transceivable) windowCleanup() {
 		case <-trx.ctx.Done():
 			return
 		case <-ticker.C:
-			ctx, cancelFunc := context.WithTimeout(context.Background(), trx.settings.StoreAccessTimeOut*time.Millisecond)
+			ctx, cancelFunc := context.WithTimeout(context.Background(), trx.settings.StoreAccessTimeOut)
 			for _, request := range trx.requestStore.List(ctx) {
 				if time.Since(request.TimeSent) > trx.settings.PduExpireTimeOut {
 					_ = trx.requestStore.Delete(ctx, request.GetSequenceNumber())

--- a/transceivable.go
+++ b/transceivable.go
@@ -136,7 +136,7 @@ func (trx *transceivable) windowCleanup() {
 			cancelFunc() //defer should not be used because we are inside loop
 			if closed {
 				go func() {
-					_ = trx.closing(ExplicitClosing)
+					_ = trx.closing(ExpiredRequestClosing)
 				}()
 				return
 			}

--- a/transceivable_test.go
+++ b/transceivable_test.go
@@ -250,7 +250,7 @@ func TestTRXSubmitSM_with_WindowConfig(t *testing.T) {
 				ExpireCheckTimer:      10 * time.Second,
 				MaxWindowSize:         30,
 				EnableAutoRespond:     false,
-				StoreAccessTimeOut:    100,
+				StoreAccessTimeOut:    100 * time.Millisecond,
 			},
 
 			OnClosed: func(state State) {
@@ -316,7 +316,7 @@ func TestTRXSubmitSM_with_WindowConfig_and_AutoRespond(t *testing.T) {
 				ExpireCheckTimer:      10 * time.Second,
 				MaxWindowSize:         30,
 				EnableAutoRespond:     true,
-				StoreAccessTimeOut:    100,
+				StoreAccessTimeOut:    100 * time.Millisecond,
 			},
 
 			OnClosed: func(state State) {

--- a/transmittable.go
+++ b/transmittable.go
@@ -62,7 +62,7 @@ func (tx *transmittable) close() {
 		// concurrent-map has no func to verify initialization
 		// we need to do the same check in
 		if tx.settings.WindowedRequestTracking != nil {
-			ctx, cancelFunc := context.WithTimeout(context.Background(), tx.settings.StoreAccessTimeOut*time.Millisecond)
+			ctx, cancelFunc := context.WithTimeout(context.Background(), tx.settings.StoreAccessTimeOut)
 			defer cancelFunc()
 			var size int
 			size, err := tx.requestStore.Length(ctx)
@@ -207,7 +207,7 @@ func (tx *transmittable) write(p pdu.PDU) (n int, err error) {
 	}
 
 	if tx.settings.WindowedRequestTracking != nil && tx.settings.MaxWindowSize > 0 && isAllowPDU(p) {
-		ctx, cancelFunc := context.WithTimeout(context.Background(), tx.settings.StoreAccessTimeOut*time.Millisecond)
+		ctx, cancelFunc := context.WithTimeout(context.Background(), tx.settings.StoreAccessTimeOut)
 		defer cancelFunc()
 		var length int
 		length, err = tx.requestStore.Length(ctx)


### PR DESCRIPTION
This PR includes multiple bug fixes and a minor change to make code more readable.
- Changed the receiver names for Receivable, Transmittable and Transceivable. They were all using `t`, i change it to `tr`,`tx, and `trx`, so it more easy to understand what the function receiver is.
- The closing function from transmittable and receivable, no longer calls the OnClosed handler, they will now call the transceivable closing function that will now handle closing process and call the OnClosed handle.
- The only closing state that will not trigger OnClosed call is `ExplicitClosing`.  This is the current behavior, only the comment has been change to indicate this behavior. 
- Removed useless call to close() in the rebind() function. rebind() is only called when closing() fucntion has been called anyway.
- Added new closing state to help indicate when a bind has been closed because the user request it after handling a expired request. 
- Fixed a bug in the windowCleanup function that would wait indefinitely on wg.wait function. 
- Removed erroneous multiplication of milliseconds for some timers 

Will resolve #170 