### PR TITLE
feat: makes getting concat info work for 16-bit reference

### DIFF
--- a/example/transceiver_with_auto_response/main.go
+++ b/example/transceiver_with_auto_response/main.go
@@ -73,7 +73,7 @@ func sendingAndReceiveSMS(wg *sync.WaitGroup) {
 }
 
 func handlePDU() func(pdu.PDU, bool) {
-	concatenated := map[uint8][]string{}
+	concatenated := map[uint16][]string{}
 	return func(p pdu.PDU, _ bool) {
 		switch pd := p.(type) {
 		case *pdu.SubmitSMResp:

--- a/pdu/UDH.go
+++ b/pdu/UDH.go
@@ -152,7 +152,7 @@ func (u UDH) FindInfoElement(id byte) (ie *InfoElement, found bool) {
 // GetConcatInfo return the FIRST concatenated message IE,
 // For 8-bit reference, mref will be a byte value (0-255)
 // For 16-bit reference, mref will be a uint16 value (0-65535) converted to uint
-func (u UDH) GetConcatInfo() (totalParts, partNum byte, mref uint, found bool) {
+func (u UDH) GetConcatInfo() (totalParts, partNum byte, mref uint16, found bool) {
 	if len(u) == 0 {
 		found = false
 		return
@@ -160,7 +160,7 @@ func (u UDH) GetConcatInfo() (totalParts, partNum byte, mref uint, found bool) {
 
 	// Check for 8-bit reference
 	if ie, ok := u.FindInfoElement(data.UDH_CONCAT_MSG_8_BIT_REF); ok && len(ie.Data) == 3 {
-		mref = uint(ie.Data[0])
+		mref = uint16(ie.Data[0])
 		totalParts = ie.Data[1]
 		partNum = ie.Data[2]
 		found = ok
@@ -169,7 +169,7 @@ func (u UDH) GetConcatInfo() (totalParts, partNum byte, mref uint, found bool) {
 
 	// Check for 16-bit reference
 	if ie, ok := u.FindInfoElement(data.UDH_CONCAT_MSG_16_BIT_REF); ok && len(ie.Data) == 4 {
-		mref = uint(ie.Data[0])<<8 | uint(ie.Data[1])
+		mref = uint16(ie.Data[0])<<8 | uint16(ie.Data[1])
 		totalParts = ie.Data[2]
 		partNum = ie.Data[3]
 		found = ok

--- a/pdu/UDH.go
+++ b/pdu/UDH.go
@@ -151,7 +151,7 @@ func (u UDH) FindInfoElement(id byte) (ie *InfoElement, found bool) {
 
 // GetConcatInfo return the FIRST concatenated message IE,
 // For 8-bit reference, mref will be a byte value (0-255)
-// For 16-bit reference, mref will be a uint16 value (0-65535) converted to uint
+// For 16-bit reference, mref will be a uint16 value (0-65535)
 func (u UDH) GetConcatInfo() (totalParts, partNum byte, mref uint16, found bool) {
 	if len(u) == 0 {
 		found = false

--- a/pdu/UDH_test.go
+++ b/pdu/UDH_test.go
@@ -24,10 +24,23 @@ func TestUserDataHeader(t *testing.T) {
 		require.True(t, found)
 		require.Equal(t, totalParts, byte(2))
 		require.Equal(t, sequence, byte(1))
-		require.Equal(t, reference, uint8(12))
+		require.Equal(t, reference, uint(12))
 	})
 
-	t.Run("unmarshalBinaryUDHConcatMessage", func(t *testing.T) {
+	t.Run("marshalBinaryUDHConcatMessage (16 bit)", func(t *testing.T) {
+		u := UDH{NewIEConcatMessage16Bit(2, 1, 1234)}
+		b, err := u.MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, "06080404d20201", toHex(b))
+
+		totalParts, sequence, reference, found := u.GetConcatInfo()
+		require.True(t, found)
+		require.Equal(t, totalParts, byte(2))
+		require.Equal(t, sequence, byte(1))
+		require.Equal(t, reference, uint(1234))
+	})
+
+	t.Run("unmarshalBinaryUDHConcatMessage (8 bit)", func(t *testing.T) {
 		u, rd := new(UDH), []byte{0x05, 0x00, 0x03, 0x0c, 0x02, 0x01}
 		read, err := u.UnmarshalBinary(rd)
 		require.False(t, read <= 0)
@@ -39,10 +52,29 @@ func TestUserDataHeader(t *testing.T) {
 		require.Equal(t, "0500030c0201", toHex(b))
 	})
 
+	t.Run("unmarshalBinaryUDHConcatMessage (16 bit)", func(t *testing.T) {
+		u, rd := new(UDH), []byte{0x06, 0x08, 0x04, 0x04, 0xd2, 0x02, 0x01}
+		read, err := u.UnmarshalBinary(rd)
+		require.False(t, read <= 0)
+
+		require.NoError(t, err)
+
+		totalParts, sequence, reference, found := u.GetConcatInfo()
+		require.True(t, found)
+		require.Equal(t, totalParts, byte(2))
+		require.Equal(t, sequence, byte(1))
+		require.Equal(t, reference, uint(1234))
+
+		b, err := u.MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, "06080404d20201", toHex(b))
+	})
+
 	t.Run("unmarshalBinaryUDHConcatMessage failed", func(t *testing.T) {
 		failedList := [][]byte{
-			{0x04, 0x00, 0x02, 0x02, 0x01},
-			{0x04, 0x08, 0x02, 0x02, 0x01},
+			{0x04, 0x00, 0x02, 0x02, 0x01},       // Invalid 8-bit UDH (wrong length)
+			{0x04, 0x08, 0x02, 0x02, 0x01},       // Invalid 16-bit UDH (wrong length)
+			{0x05, 0x08, 0x03, 0x04, 0xd2, 0x01}, // Invalid 16-bit UDH (missing part number)
 		}
 		u := new(UDH)
 		for _, data := range failedList {

--- a/pdu/UDH_test.go
+++ b/pdu/UDH_test.go
@@ -24,7 +24,7 @@ func TestUserDataHeader(t *testing.T) {
 		require.True(t, found)
 		require.Equal(t, totalParts, byte(2))
 		require.Equal(t, sequence, byte(1))
-		require.Equal(t, reference, uint(12))
+		require.Equal(t, reference, uint16(12))
 	})
 
 	t.Run("marshalBinaryUDHConcatMessage (16 bit)", func(t *testing.T) {
@@ -37,7 +37,7 @@ func TestUserDataHeader(t *testing.T) {
 		require.True(t, found)
 		require.Equal(t, totalParts, byte(2))
 		require.Equal(t, sequence, byte(1))
-		require.Equal(t, reference, uint(1234))
+		require.Equal(t, reference, uint16(1234))
 	})
 
 	t.Run("unmarshalBinaryUDHConcatMessage (8 bit)", func(t *testing.T) {
@@ -63,7 +63,7 @@ func TestUserDataHeader(t *testing.T) {
 		require.True(t, found)
 		require.Equal(t, totalParts, byte(2))
 		require.Equal(t, sequence, byte(1))
-		require.Equal(t, reference, uint(1234))
+		require.Equal(t, reference, uint16(1234))
 
 		b, err := u.MarshalBinary()
 		require.NoError(t, err)


### PR DESCRIPTION
Here is a PR that returns appropriate concatenated info when using a 16-bit reference.

I also suggest making the fields totalParts and partNum as uint instead of byte. Please let me know in case.